### PR TITLE
TICK-372 Using raw memory allocators, Python 3.6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,39 @@ matrix:
   include:
   - os: linux
     language: generic
-    env: TOXENV=py34
+    env: PYVER=3.4.6
   - os: linux
     language: generic
-    env: TOXENV=py35
+    env: PYVER=3.5.3
+  - os: linux
+    language: generic
+    env: PYVER=3.6.1
   - os: osx
     language: generic
-    env: TOXENV=py34
+    env: PYVER=3.4.6
   - os: osx
     language: generic
-    env: TOXENV=py35
+    env: PYVER=3.5.3
+  - os: osx
+    language: generic
+    env: PYVER=3.6.1
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis_install_mac.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source .travis_install_linux.sh; fi
 
 install:
+  - pyenv local ${PYVER}
   - python -m pip install --quiet -U pip
   - python -m pip install --quiet numpy pandas
   - python -m pip install -r requirements.txt
   - python -m pip install sphinx pillow
   - python -m pip install cpplint
+  - pyenv rehash
 
 script:
   - ./build_test.sh
-  - export PYTHONPATH=${PYTHONPATH}:${TRAVIS_BUILD_DIR} && (cd doc && make doctest)
+  - export PYTHONPATH=${PYTHONPATH}:${TRAVIS_BUILD_DIR} && (cd doc && pyenv local ${PYVER} && make doctest)
 
 notifications:
   slack:

--- a/.travis_install_linux.sh
+++ b/.travis_install_linux.sh
@@ -12,22 +12,6 @@ if [ ! -d $HOME/.pyenv/bin ]
         git clone https://github.com/yyuu/pyenv.git $HOME/.pyenv
 fi
 
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
-
-eval "$(pyenv init -)"
-
-case "${TOXENV}" in
-    py34)
-        pyenv install -s 3.4.5
-        pyenv local 3.4.5
-        ;;
-    py35)
-        pyenv install -s 3.5.2
-        pyenv local 3.5.2
-        ;;
-esac
-
 if [ ! -d googletest  ] || [ ! -f googletest/CMakeLists.txt ]
     then
         git clone https://github.com/google/googletest.git
@@ -45,3 +29,9 @@ fi
 
 alias swig=/usr/local/bin/swig
 
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+eval "$(pyenv init -)"
+
+pyenv install -s ${PYVER}

--- a/.travis_install_mac.sh
+++ b/.travis_install_mac.sh
@@ -2,19 +2,7 @@
 
 brew update
 brew install swig pyenv
-
-case "${TOXENV}" in
-    py34)
-        env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s 3.4.5
-        pyenv local 3.4.5
-        ;;
-    py35)
-        env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s 3.5.2
-        pyenv local 3.5.2
-        ;;
-esac
-
-eval "$(pyenv init -)"
+brew upgrade pyenv
 
 if [ ! -d googletest ] || [ ! -f googletest/CMakeLists.txt ]
     then
@@ -22,6 +10,11 @@ if [ ! -d googletest ] || [ ! -f googletest/CMakeLists.txt ]
         (cd googletest && mkdir -p build && cd build && cmake .. && make -s)
 fi
 
-export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
-
 (cd googletest && cd build && sudo make -s install)
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+eval "$(pyenv init -)"
+
+env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s ${PYVER}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,6 +28,7 @@ except ImportError:
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- General configuration ----------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ except AttributeError:
 # Determine if we have an available BLAS implementation
 blas_info = get_info("blas_opt", 0)
 
-
 class SwigExtension(Extension):
     """This only adds information about extension construction, useful for
     library sharing

--- a/tick/base/array/src/abstractarray1d2d.h
+++ b/tick/base/array/src/abstractarray1d2d.h
@@ -175,8 +175,8 @@ AbstractArray1d2d<T>::~AbstractArray1d2d() {
     std::cout << type() << " Destructor : ~AbstractArray1d2d on " << this << std::endl;
 #endif
     // Delete owned allocations
-    if (is_data_allocation_owned && _data != nullptr) PYSHARED_FREE_ARRAY(_data);
-    if (is_indices_allocation_owned && _indices != nullptr) PYSHARED_FREE_ARRAY(_indices);
+    if (is_data_allocation_owned && _data != nullptr) TICK_PYTHON_FREE(_data);
+    if (is_indices_allocation_owned && _indices != nullptr) TICK_PYTHON_FREE(_indices);
 
     _data = nullptr;
     _indices = nullptr;
@@ -195,13 +195,13 @@ AbstractArray1d2d<T>::AbstractArray1d2d(const AbstractArray1d2d<T> &other) {
     is_data_allocation_owned = true;
     _data = nullptr;
     if (other.is_dense()) {
-        PYSHARED_ALLOC_ARRAY(_data, T, _size);
+        TICK_PYTHON_MALLOC(_data, T, _size);
         memcpy(_data, other._data, sizeof(T) * _size);
         _indices = nullptr;
     } else {
-        PYSHARED_ALLOC_ARRAY(_data, T, _size_sparse);
+        TICK_PYTHON_MALLOC(_data, T, _size_sparse);
         memcpy(_data, other._data, sizeof(T) * _size_sparse);
-        PYSHARED_ALLOC_ARRAY(_indices, INDICE_TYPE, _size_sparse);
+        TICK_PYTHON_MALLOC(_indices, INDICE_TYPE, _size_sparse);
         memcpy(_indices, other._indices, sizeof(INDICE_TYPE) * _size_sparse);
     }
 }
@@ -236,21 +236,21 @@ AbstractArray1d2d<T> &AbstractArray1d2d<T>::operator=(const AbstractArray1d2d<T>
 #endif
     if (this != &other) {
         // Delete owned allocations
-        if (is_data_allocation_owned && _data != nullptr) PYSHARED_FREE_ARRAY(_data);
-        if (is_indices_allocation_owned && _indices != nullptr) PYSHARED_FREE_ARRAY(_indices);
+        if (is_data_allocation_owned && _data != nullptr) TICK_PYTHON_FREE(_data);
+        if (is_indices_allocation_owned && _indices != nullptr) TICK_PYTHON_FREE(_indices);
         is_indices_allocation_owned = true;
         is_data_allocation_owned = true;
         _size = other._size;
         _size_sparse = other._size_sparse;
         if (other.is_dense()) {
-            PYSHARED_ALLOC_ARRAY(_data, T, _size);
+            TICK_PYTHON_MALLOC(_data, T, _size);
             memcpy(_data, other._data, sizeof(T) * _size);
             _indices = nullptr;
         } else {
             if (_size_sparse > 0) {
-                PYSHARED_ALLOC_ARRAY(_data, T, _size_sparse);
+                TICK_PYTHON_MALLOC(_data, T, _size_sparse);
                 memcpy(_data, other._data, sizeof(T) * _size_sparse);
-                PYSHARED_ALLOC_ARRAY(_indices, INDICE_TYPE, _size_sparse);
+                TICK_PYTHON_MALLOC(_indices, INDICE_TYPE, _size_sparse);
                 memcpy(_indices, other._indices, sizeof(INDICE_TYPE) * _size_sparse);
             }
         }
@@ -265,8 +265,8 @@ AbstractArray1d2d<T> &AbstractArray1d2d<T>::operator=(AbstractArray1d2d<T> &&oth
     std::cout << type() << " Move Assignement : operator = (AbstractArray1d2d && "
     << &other << ") --> " << this << std::endl;
 #endif
-    if (is_data_allocation_owned && _data != nullptr) PYSHARED_FREE_ARRAY(_data);
-    if (is_indices_allocation_owned && _indices != nullptr) PYSHARED_FREE_ARRAY(_indices);
+    if (is_data_allocation_owned && _data != nullptr) TICK_PYTHON_FREE(_data);
+    if (is_indices_allocation_owned && _indices != nullptr) TICK_PYTHON_FREE(_indices);
     _size = other._size;
     is_indices_allocation_owned = other.is_indices_allocation_owned;
     is_data_allocation_owned = other.is_data_allocation_owned;

--- a/tick/base/array/src/alloc.cpp
+++ b/tick/base/array/src/alloc.cpp
@@ -1,5 +1,7 @@
 #include "alloc.h"
 
-#ifdef DEBUG_C_ARRAY
-std::int64_t DEBUGCAllocArrayCount::count = 0;
+#if defined(DEBUG_C_ARRAY)
+
+DEBUGCAllocArrayCount_t DEBUGCAllocArrayCount;
+
 #endif

--- a/tick/base/array/src/array.h
+++ b/tick/base/array/src/array.h
@@ -234,7 +234,7 @@ Array<T>::Array(ulong size, T *data1)
     // if no one gave us data we allocate it and are now responsible for it
     if (data1 == nullptr) {
         is_data_allocation_owned = true;
-        PYSHARED_ALLOC_ARRAY(_data, T, _size);
+        TICK_PYTHON_MALLOC(_data, T, _size);
     } else {
         // Otherwise the one who gave the data is responsible for its allocation
         is_data_allocation_owned = false;
@@ -248,7 +248,7 @@ Array<T>::Array(std::initializer_list<T> data_list)
     : BaseArray<T>(true) {
     is_data_allocation_owned = true;
     _size = data_list.size();
-    PYSHARED_ALLOC_ARRAY(_data, T, _size);
+    TICK_PYTHON_MALLOC(_data, T, _size);
     size_t index = 0;
     for (auto it = data_list.begin(); it != data_list.end(); ++it) {
         _data[index] = *it;

--- a/tick/base/array/src/array2d.h
+++ b/tick/base/array/src/array2d.h
@@ -155,7 +155,7 @@ Array2d<T>::Array2d(ulong n_rows, ulong n_cols, T *data) :
     // if no one gave us data we allocate it and are now responsible for it
     if (data == nullptr) {
         is_data_allocation_owned = true;
-        PYSHARED_ALLOC_ARRAY(_data, T, _size);
+        TICK_PYTHON_MALLOC(_data, T, _size);
     } else {
         // Otherwise the one who gave the data is responsible for its allocation
         is_data_allocation_owned = false;

--- a/tick/base/array/src/basearray2d.h
+++ b/tick/base/array/src/basearray2d.h
@@ -75,14 +75,14 @@ class BaseArray2d : public AbstractArray1d2d<T> {
         if (this != &other) {
             AbstractArray1d2d<T>::operator=(other);
             if (is_row_indices_allocation_owned && _row_indices != nullptr)
-                PYSHARED_FREE_ARRAY(_row_indices);
+                TICK_PYTHON_FREE(_row_indices);
             _row_indices = nullptr;
             is_row_indices_allocation_owned = true;
             _n_cols = other._n_cols;
             _n_rows = other._n_rows;
             _size = _n_cols * _n_rows;
             if (other.is_sparse()) {
-                PYSHARED_ALLOC_ARRAY(_row_indices, INDICE_TYPE, _n_rows + 1);
+                TICK_PYTHON_MALLOC(_row_indices, INDICE_TYPE, _n_rows + 1);
                 memcpy(_row_indices, other._row_indices, sizeof(INDICE_TYPE) * (_n_rows + 1));
             }
         }
@@ -94,7 +94,7 @@ class BaseArray2d : public AbstractArray1d2d<T> {
     BaseArray2d &operator=(BaseArray2d<T> &&other) {
         AbstractArray1d2d<T>::operator=(std::move(other));
         if (is_row_indices_allocation_owned && _row_indices != nullptr)
-            PYSHARED_FREE_ARRAY(_row_indices);
+            TICK_PYTHON_FREE(_row_indices);
         _row_indices = other._row_indices;
         other._row_indices = nullptr;
         is_row_indices_allocation_owned = other.is_row_indices_allocation_owned;
@@ -106,7 +106,7 @@ class BaseArray2d : public AbstractArray1d2d<T> {
 
     //! @brief Destructor
     virtual ~BaseArray2d() {
-        if (is_row_indices_allocation_owned && _row_indices != nullptr) PYSHARED_FREE_ARRAY(_row_indices);
+        if (is_row_indices_allocation_owned && _row_indices != nullptr) TICK_PYTHON_FREE(_row_indices);
     }
 
  private:
@@ -138,7 +138,7 @@ BaseArray2d<T>::BaseArray2d(const BaseArray2d<T> &other) : AbstractArray1d2d<T>(
     is_row_indices_allocation_owned = true;
     _row_indices = nullptr;
     if (other.is_sparse()) {
-        PYSHARED_ALLOC_ARRAY(_row_indices, INDICE_TYPE, _n_rows + 1);
+        TICK_PYTHON_MALLOC(_row_indices, INDICE_TYPE, _n_rows + 1);
         memcpy(_row_indices, other._row_indices, sizeof(INDICE_TYPE) * (_n_rows + 1));
     }
 }

--- a/tick/base/array/src/sarray.h
+++ b/tick/base/array/src/sarray.h
@@ -225,7 +225,7 @@ T *SArray<T>::_clear() {
 template<typename T>
 void SArray<T>::clear() {
     if (_clear()) {
-        PYSHARED_FREE_ARRAY(_data);
+        TICK_PYTHON_FREE(_data);
     }
     _data = nullptr;
 }

--- a/tick/base/array/src/sarray2d.h
+++ b/tick/base/array/src/sarray2d.h
@@ -247,7 +247,7 @@ T *SArray2d<T>::_clear() {
 template<typename T>
 void SArray2d<T>::clear() {
     if (_clear()) {
-        PYSHARED_FREE_ARRAY(_data);
+        TICK_PYTHON_FREE(_data);
     }
     _data = nullptr;
 }

--- a/tick/base/array/src/ssparsearray.h
+++ b/tick/base/array/src/ssparsearray.h
@@ -211,9 +211,9 @@ std::shared_ptr<SSparseArray<T>> SSparseArray<T>::new_ptr(ulong size, ulong size
         return aptr;
     }
     T *data;
-    PYSHARED_ALLOC_ARRAY(data, T, size_sparse);
+    TICK_PYTHON_MALLOC(data, T, size_sparse);
     INDICE_TYPE *indices;
-    PYSHARED_ALLOC_ARRAY(indices, INDICE_TYPE, size_sparse);
+    TICK_PYTHON_MALLOC(indices, INDICE_TYPE, size_sparse);
     aptr->set_data_indices(data, indices, size, size_sparse);
     return aptr;
 }
@@ -289,8 +289,8 @@ void SSparseArray<T>::clear() {
     bool flag_desallocate_data;
     bool flag_desallocate_indices;
     _clear(flag_desallocate_data, flag_desallocate_indices);
-    if (flag_desallocate_data) PYSHARED_FREE_ARRAY(_data);
-    if (flag_desallocate_indices) PYSHARED_FREE_ARRAY(_indices);
+    if (flag_desallocate_data) TICK_PYTHON_FREE(_data);
+    if (flag_desallocate_indices) TICK_PYTHON_FREE(_indices);
     _data = nullptr;
     _indices = nullptr;
 }

--- a/tick/base/array/src/ssparsearray2d.h
+++ b/tick/base/array/src/ssparsearray2d.h
@@ -262,11 +262,11 @@ std::shared_ptr<SSparseArray2d<T>> SSparseArray2d<T>::new_ptr(ulong n_rows, ulon
         return aptr;
     }
     T *data;
-    PYSHARED_ALLOC_ARRAY(data, T, size_sparse);
+    TICK_PYTHON_MALLOC(data, T, size_sparse);
     INDICE_TYPE *indices;
-    PYSHARED_ALLOC_ARRAY(indices, INDICE_TYPE, size_sparse);
+    TICK_PYTHON_MALLOC(indices, INDICE_TYPE, size_sparse);
     INDICE_TYPE *row_indices;
-    PYSHARED_ALLOC_ARRAY(row_indices, INDICE_TYPE, n_rows + 1);
+    TICK_PYTHON_MALLOC(row_indices, INDICE_TYPE, n_rows + 1);
     row_indices[n_rows] = size_sparse;
     aptr->set_data_indices_rowindices(data, indices, row_indices, n_rows, n_cols);
     return aptr;
@@ -375,9 +375,9 @@ void SSparseArray2d<T>::clear() {
     bool flag_desallocate_indices;
     bool flag_desallocate_row_indices;
     _clear(flag_desallocate_data, flag_desallocate_indices, flag_desallocate_row_indices);
-    if (flag_desallocate_data) PYSHARED_FREE_ARRAY(_data);
-    if (flag_desallocate_indices) PYSHARED_FREE_ARRAY(_indices);
-    if (flag_desallocate_row_indices) PYSHARED_FREE_ARRAY(_row_indices);
+    if (flag_desallocate_data) TICK_PYTHON_FREE(_data);
+    if (flag_desallocate_indices) TICK_PYTHON_FREE(_indices);
+    if (flag_desallocate_row_indices) TICK_PYTHON_FREE(_row_indices);
     _data = nullptr;
     _indices = nullptr;
     _row_indices = nullptr;

--- a/tick/base/array/src/varray.h
+++ b/tick/base/array/src/varray.h
@@ -128,7 +128,7 @@ void VArray<T>::set_size(ulong newsize, bool flagRemember) {
 #ifdef DEBUG_VARRAY
     std::cout << "VArray : SetSize : Alloc data of sizeAlloc=" << newSizeAlloc << " on " << this << std::endl;
 #endif
-    PYSHARED_ALLOC_ARRAY(tempPtr, T, newSizeAlloc);
+    TICK_PYTHON_MALLOC(tempPtr, T, newSizeAlloc);
     if (flagRemember) memcpy(tempPtr, Array<T>::_data, sizeof(T) * Array<T>::_size);
 
     VArray<T>::clear();

--- a/tick/base/array/src/vector_operations.h
+++ b/tick/base/array/src/vector_operations.h
@@ -58,7 +58,7 @@ using vector_operations = detail::vector_operations_unoptimized<T>;
 
 #else  // if defined(TICK_CBLAS_AVAILABLE)
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 
 #include <Accelerate/Accelerate.h>
 
@@ -69,7 +69,7 @@ using vector_operations = detail::vector_operations_unoptimized<T>;
 
 #include <cblas.h>
 
-#endif
+#endif  // defined(__APPLE__)
 
 namespace tick {
 

--- a/tick/base/tests/src/CMakeLists.txt
+++ b/tick/base/tests/src/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(tick_test_base utils_gtest.cpp)
 
-target_link_libraries(tick_test_base ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_TEST_LIBS} base)
+target_link_libraries(tick_test_base ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_TEST_LIBS} array base )

--- a/tick/inference/src/CMakeLists.txt
+++ b/tick/inference/src/CMakeLists.txt
@@ -5,4 +5,4 @@ add_library(inference EXCLUDE_FROM_ALL
         hawkes_basis_kernels.cpp hawkes_basis_kernels.h
         hawkes_sumgaussians.h hawkes_sumgaussians.cpp)
 
-target_link_libraries(inference base model)
+target_link_libraries(inference base array model)

--- a/tick/optim/model/src/CMakeLists.txt
+++ b/tick/optim/model/src/CMakeLists.txt
@@ -22,4 +22,4 @@ add_library(model EXCLUDE_FROM_ALL
         variants/hawkes_fixed_sumexpkern_leastsq_list.h variants/hawkes_fixed_sumexpkern_leastsq_list.cpp
         )
 
-target_link_libraries(model base)
+target_link_libraries(model base array)

--- a/tick/optim/model/tests/src/CMakeLists.txt
+++ b/tick/optim/model/tests/src/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(tick_test_model models_gtest.cpp hawkes_models_gtests.cpp)
 
-target_link_libraries(tick_test_model ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_TEST_LIBS} base model)
+target_link_libraries(tick_test_model ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_TEST_LIBS} base array model)

--- a/tick/simulation/src/CMakeLists.txt
+++ b/tick/simulation/src/CMakeLists.txt
@@ -13,4 +13,4 @@ add_library(simulation EXCLUDE_FROM_ALL
         hawkes_baselines/constant_baseline.cpp hawkes_baselines/constant_baseline.h
         hawkes_baselines/timefunction_baseline.cpp hawkes_baselines/timefunction_baseline.h)
 
-target_link_libraries(simulation random base)
+target_link_libraries(simulation random base array)


### PR DESCRIPTION
Only significant change is that we now use `PyMem_Raw*` functions.'

Also added Python 3.6 to the list of tested versions for Travis.