### PR TITLE
TICK-397 Building on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -285,13 +285,16 @@ def create_extension(extension_name, module_dir,
     else:
         extra_compile_args.extend(min_extra_compile_args)
 
-    # Added -Wall to get all warnings and -Werror to treat them as errors
-    extra_compile_args.append("-Wall")
-    extra_compile_args.append("-Werror")
+    if os.name == 'nt':
+        extra_compile_args.append("-DBUILDING_DLL")
+    else:
+        # Added -Wall to get all warnings and -Werror to treat them as errors
+        extra_compile_args.append("-Wall")
+        extra_compile_args.append("-Werror")
 
-    # This warning is turned off because SWIG generates files that triggers the
-    # warning
-    extra_compile_args.append("-Wno-uninitialized")
+        # This warning is turned off because SWIG generates files that triggers the
+        # warning
+        extra_compile_args.append("-Wno-uninitialized")
 
     # Include directory of module
     mod = SwigPath(module_dir, extension_name)
@@ -339,6 +342,8 @@ def create_extension(extension_name, module_dir,
             # $ORIGIN refers to the location of the current shared object file
             # at runtime
             runtime_library_dirs.append("\$ORIGIN/%s" % rel_path)
+        elif os.name == 'nt':
+            pass
         else:  # Assuming non-Windows builds for now
             # For OSX builds we use @loader_path instead
             extra_link_args.append(
@@ -351,6 +356,8 @@ def create_extension(extension_name, module_dir,
     filename = swig_path.lib_filename
     if platform.system() == 'Linux':
         extra_link_args.append('-Wl,-soname,%s' % filename)
+    elif os.name == 'nt':
+        pass
     else:
         # For OSX the install_name needs to be prefixed with @rpath
         extra_link_args.append('-Wl,-install_name,@rpath/%s' % filename)

--- a/tick/base/array_test/src/timer.h
+++ b/tick/base/array_test/src/timer.h
@@ -13,10 +13,11 @@
 
 #include "defs.h"
 
-#include <ctime>
-
 #include <iostream>
+#include <sstream>
 #include <iomanip>
+
+#include <ctime>
 
 #define START_TIMER(i, message) \
 clock_t __timer ## i = clock(); std::string __timer_message ## i = message

--- a/tick/base/src/debug.h
+++ b/tick/base/src/debug.h
@@ -22,8 +22,12 @@
 
 #include "defs.h"
 
+#ifndef _WIN32
+
 #include <execinfo.h>
 #include <unistd.h>
+
+#endif  // _WIN32
 
 #include <string>
 #include <iostream>
@@ -56,6 +60,7 @@ class TemporaryLog {
   }
 
   TemporaryLog &insert_backtrace() {
+#ifndef _WIN32
     std::array<void *, 100> stack_addresses;
 
     const int num_addresses = backtrace(stack_addresses.data(), stack_addresses.size());
@@ -65,7 +70,7 @@ class TemporaryLog {
 
     for (int j = 0; j < std::min(num_addresses, 10); ++j)
       (*this) << strings[j] << '\n';
-
+#endif
     return *this;
   }
 
@@ -105,7 +110,11 @@ struct LogExitCout {
 /**
  * Inserts filename, linenumber and function name into stream
  */
+#ifdef _WIN32
+#define TICK_LOG_PREFIX __FILE__ ":"  << __LINE__ << " in " << __FUNCTION__ << ": "
+#else
 #define TICK_LOG_PREFIX __FILE__ ":"  << __LINE__ << " in " << __PRETTY_FUNCTION__ << ": "
+#endif
 
 /**
  * \defgroup error_mod Error management

--- a/tick/base/src/defs.h
+++ b/tick/base/src/defs.h
@@ -47,4 +47,12 @@
 typedef std::uint64_t ulong;
 #endif
 
+#ifndef ushort
+typedef std::uint16_t ushort;
+#endif
+
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif  // _USE_MATH_DEFINES
+
 #endif  // TICK_BASE_SRC_DEFS_H_

--- a/tick/base/src/interruption.cpp
+++ b/tick/base/src/interruption.cpp
@@ -5,8 +5,6 @@
 #include <iostream>
 #include <csignal>
 
-std::atomic<bool> Interruption::flag_interrupt(false);
-
 const char *Interruption::what() const noexcept {
     return "Process was interrupted with signal SIGINT";
 }

--- a/tick/base/src/interruption.h
+++ b/tick/base/src/interruption.h
@@ -11,6 +11,8 @@
 
 // License: BSD 3 clause
 
+#include "defs.h"
+
 #include <atomic>
 #include <exception>
 
@@ -19,31 +21,40 @@
  */
 class Interruption : public std::exception {
  private:
-    static std::atomic<bool> flag_interrupt;
+    static std::atomic<bool>& get_flag_interrupt() {
+        static std::atomic<bool> flag_interrupt;
+        return flag_interrupt;
+    }
 
  public:
     //! @brief Simple constructor
     Interruption() {}
 
-    const char *what() const noexcept override;
+    DLL_PUBLIC const char *what() const noexcept override;
 
     //! \cond
     //! @brief Notifies an interruption has been detected (not to be called directly)
-    inline static void set() { flag_interrupt = true; }
+    inline static void set() {
+        auto& flag_interrupt = get_flag_interrupt();
+        flag_interrupt = true;
+    }
 
     //! @brief Reset interruption flag. Called when interruption has been processed
     //! (not to be called directly)
-    inline static void reset() { flag_interrupt = false; }
+    inline static void reset() {
+        auto& flag_interrupt = get_flag_interrupt();
+        flag_interrupt = false;
+     }
     //! \endcond
 
     //! @brief Test whether Ctrl-C interruption has been detected
     //! \return true if interruption detected false otherwise
-    inline static bool is_raised() { return flag_interrupt; }
+    inline static bool is_raised() { return get_flag_interrupt(); }
 
     //! @brief Throw an exception (of type Interruption) if interruption has been detected
     //! \warning Never call it from inside a thread unless you use
     //! ::parallel_map or ::parallel_run
-    inline static void throw_if_raised() { if (flag_interrupt) throw (Interruption()); }
+    inline static void throw_if_raised() { if (get_flag_interrupt()) throw (Interruption()); }
 };
 
 #endif  // TICK_BASE_SRC_INTERRUPTION_H_

--- a/tick/base/src/math/normal_distribution.h
+++ b/tick/base/src/math/normal_distribution.h
@@ -11,7 +11,7 @@
 
 extern double standard_normal_cdf(double x);
 
-extern double standard_normal_inv_cdf(const double q);
+extern DLL_PUBLIC double standard_normal_inv_cdf(const double q);
 
 extern void standard_normal_inv_cdf(ArrayDouble &q, ArrayDouble &out);
 

--- a/tick/base/src/math/t2exp.h
+++ b/tick/base/src/math/t2exp.h
@@ -17,6 +17,8 @@
     WILL NOT BE LIABLE FOR DATA LOSS, DAMAGES, LOSS OF PROFITS OR
     ANY OTHER KIND OF LOSS WHILE USING OR MISUSING THIS SOFTWARE.
 -------------------------------------------------------------- */
+#include "defs.h"
+
 #include <cmath>
 
 #ifndef TICK_BASE_SRC_MATH_T2EXP_H_
@@ -42,7 +44,7 @@ extern "C" {
                 exp() function - that is either 0 or INF.
 -------------------------------------------------------------- */
 
-extern double t2exp(double arg);
+extern DLL_PUBLIC double t2exp(double arg);
 
 /* --------------------------------------------------------------
     Name:       t2expini

--- a/tick/base/src/time_func.h
+++ b/tick/base/src/time_func.h
@@ -18,7 +18,7 @@
 // TODO: Do an abstract class... then small classes for constant TF, interpolated, dichotomic...
 
 //! @brief this class allows us to extrapolate points samples into continuous temporal function
-class TimeFunction {
+class DLL_PUBLIC TimeFunction {
  public:
     //! @brief The different interpolation mode
     enum class InterMode {

--- a/tick/base/swig/base_module.i
+++ b/tick/base/swig/base_module.i
@@ -2,6 +2,9 @@
 
 %module base
 
+// see: http://www.swig.org/Doc3.0/Windows.html
+#define DLL_PUBLIC
+
 %include defs.i
 %include serialization.i
 

--- a/tick/optim/model/src/base/hawkes_list.h
+++ b/tick/optim/model/src/base/hawkes_list.h
@@ -11,7 +11,7 @@
 /** \class ModelHawkesList
  * \brief Base class of Hawkes models handling several realizations
  */
-class ModelHawkesList : public ModelHawkes {
+class DLL_PUBLIC ModelHawkesList : public ModelHawkes {
  protected:
   //! @brief number of given realization (size of timestamps_list)
   ulong n_realizations;

--- a/tick/optim/model/src/base/hawkes_model.h
+++ b/tick/optim/model/src/base/hawkes_model.h
@@ -9,7 +9,7 @@
 /** \class ModelHawkes
  * \brief Base class of Hawkes models
  */
-class ModelHawkes : public Model {
+class DLL_PUBLIC ModelHawkes : public Model {
  protected:
   //! @brief Maximum number of threads that will be used for computation
   //! if < 1 then it is set to the maximum number of threads

--- a/tick/optim/model/src/base/hawkes_single.h
+++ b/tick/optim/model/src/base/hawkes_single.h
@@ -9,7 +9,7 @@
 /** \class ModelHawkesSingle
  * \brief Base class of Hawkes models handling only one realization
  */
-class ModelHawkesSingle : public ModelHawkes {
+class DLL_PUBLIC ModelHawkesSingle : public ModelHawkes {
  protected:
   //! @brief The process timestamps (a list of arrays)
   SArrayDoublePtrList1D timestamps;

--- a/tick/optim/model/src/coxreg_partial_lik.h
+++ b/tick/optim/model/src/coxreg_partial_lik.h
@@ -9,8 +9,7 @@
 
 #include "model.h"
 
-
-class ModelCoxRegPartialLik : public Model {
+class DLL_PUBLIC ModelCoxRegPartialLik : public Model {
  private:
     ArrayDouble inner_prods;
     ArrayDouble s1;

--- a/tick/optim/model/src/hawkes_fixed_expkern_leastsq.h
+++ b/tick/optim/model/src/hawkes_fixed_expkern_leastsq.h
@@ -12,7 +12,7 @@ class ModelHawkesFixedExpKernLeastSqList;
  * \brief Class for computing L2 Contrast function and gradient for Hawkes processes with
  * exponential kernels with fixed exponent (i.e., alpha*beta*e^{-beta t}, with fixed beta)
  */
-class ModelHawkesFixedExpKernLeastSq : public ModelHawkesSingle {
+class DLL_PUBLIC ModelHawkesFixedExpKernLeastSq : public ModelHawkesSingle {
   void allocate_weights();
   /**
    * @brief Precomputations of intermediate values for dimension i

--- a/tick/optim/model/src/hawkes_fixed_expkern_loglik.h
+++ b/tick/optim/model/src/hawkes_fixed_expkern_loglik.h
@@ -19,7 +19,7 @@ class ModelHawkesFixedExpKernLogLikList;
  * exponential kernels with fixed exponent (i.e., \f$ \alpha \beta e^{-\beta t} \f$, with fixed
  * decay)
  */
-class ModelHawkesFixedExpKernLogLik : public ModelHawkesSingle {
+class DLL_PUBLIC ModelHawkesFixedExpKernLogLik : public ModelHawkesSingle {
  private:
   //! @brief Value of decay for this model
   double decay;

--- a/tick/optim/model/src/hawkes_fixed_sumexpkern_leastsq.h
+++ b/tick/optim/model/src/hawkes_fixed_sumexpkern_leastsq.h
@@ -11,7 +11,7 @@
  * sum exponential kernels with fixed exponent (i.e., \sum_u alpha_u*beta_u*e^{-beta_u t},
  * with fixed beta)
  */
-class ModelHawkesFixedSumExpKernLeastSq : public ModelHawkesSingle {
+class DLL_PUBLIC ModelHawkesFixedSumExpKernLeastSq : public ModelHawkesSingle {
   //! @brief Some arrays used for intermediate computings.
   ArrayDouble2dList1D E, Dgg, C;
 

--- a/tick/optim/model/src/linreg.h
+++ b/tick/optim/model/src/linreg.h
@@ -12,7 +12,7 @@
 
 #include <cereal/types/base_class.hpp>
 
-class ModelLinReg : public ModelGeneralizedLinear, public ModelLipschitz {
+class DLL_PUBLIC ModelLinReg : public ModelGeneralizedLinear, public ModelLipschitz {
  public:
   ModelLinReg(const SBaseArrayDouble2dPtr features,
               const SArrayDoublePtr labels,

--- a/tick/optim/model/src/linreg_with_intercepts.h
+++ b/tick/optim/model/src/linreg_with_intercepts.h
@@ -10,7 +10,7 @@
 #include "model_generalized_linear_with_intercepts.h"
 #include "model_lipschitz.h"
 
-class ModelLinRegWithIntercepts : public ModelGeneralizedLinearWithIntercepts,
+class DLL_PUBLIC ModelLinRegWithIntercepts : public ModelGeneralizedLinearWithIntercepts,
                                   public ModelLipschitz {
  public:
   ModelLinRegWithIntercepts(const SBaseArrayDouble2dPtr features,

--- a/tick/optim/model/src/logreg.h
+++ b/tick/optim/model/src/logreg.h
@@ -13,7 +13,7 @@
 
 // TODO: labels should be a ArrayInt
 
-class ModelLogReg : public ModelGeneralizedLinear, public ModelLipschitz {
+class DLL_PUBLIC ModelLogReg : public ModelGeneralizedLinear, public ModelLipschitz {
  public:
   ModelLogReg(const SBaseArrayDouble2dPtr features,
               const SArrayDoublePtr labels,

--- a/tick/optim/model/src/model_generalized_linear.h
+++ b/tick/optim/model/src/model_generalized_linear.h
@@ -8,7 +8,7 @@
 
 #include "model_labels_features.h"
 
-class ModelGeneralizedLinear : public ModelLabelsFeatures {
+class DLL_PUBLIC ModelGeneralizedLinear : public ModelLabelsFeatures {
  protected:
   ArrayDouble features_norm_sq;
 

--- a/tick/optim/model/src/model_generalized_linear_with_intercepts.h
+++ b/tick/optim/model/src/model_generalized_linear_with_intercepts.h
@@ -9,7 +9,7 @@
 #include "model_generalized_linear.h"
 #include "model_labels_features.h"
 
-class ModelGeneralizedLinearWithIntercepts : public ModelGeneralizedLinear {
+class DLL_PUBLIC ModelGeneralizedLinearWithIntercepts : public ModelGeneralizedLinear {
  protected:
   /**
    * Computes gradient fo ith observation

--- a/tick/optim/model/src/model_labels_features.h
+++ b/tick/optim/model/src/model_labels_features.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-class ModelLabelsFeatures : public virtual Model {
+class DLL_PUBLIC ModelLabelsFeatures : public virtual Model {
  protected:
   ulong n_samples, n_features;
 

--- a/tick/optim/model/src/model_lipschitz.h
+++ b/tick/optim/model/src/model_lipschitz.h
@@ -13,7 +13,7 @@
  * \class ModelLipschitz
  * \brief An interface for a Model with the ability to compute Lipschitz constants
  */
-class ModelLipschitz : public virtual Model {
+class DLL_PUBLIC ModelLipschitz : public virtual Model {
  protected:
   //! True if all lipschitz constants are already computed
   bool ready_lip_consts;

--- a/tick/optim/model/src/poisreg.h
+++ b/tick/optim/model/src/poisreg.h
@@ -17,7 +17,7 @@ enum class LinkType {
   exponential
 };
 
-class ModelPoisReg : public ModelGeneralizedLinear {
+class DLL_PUBLIC ModelPoisReg : public ModelGeneralizedLinear {
  private:
   LinkType link_type;
 

--- a/tick/optim/model/src/sccs.h
+++ b/tick/optim/model/src/sccs.h
@@ -10,7 +10,7 @@
 #include "base.h"
 #include "model_lipschitz.h"
 
-class ModelSCCS : public ModelLipschitz  {
+class DLL_PUBLIC ModelSCCS : public ModelLipschitz  {
  protected:
   ulong n_intervals;
   ulong n_lags;

--- a/tick/optim/model/src/variants/hawkes_fixed_expkern_leastsq_list.h
+++ b/tick/optim/model/src/variants/hawkes_fixed_expkern_leastsq_list.h
@@ -12,7 +12,7 @@
  * exponential kernels with fixed exponent (i.e., alpha*beta*e^{-beta t}, with fixed beta)
  * on a list of realizations
  */
-class ModelHawkesFixedExpKernLeastSqList : public ModelHawkesLeastSqList {
+class DLL_PUBLIC ModelHawkesFixedExpKernLeastSqList : public ModelHawkesLeastSqList {
   //! @brief Some arrays used for intermediate computings. They are initialized in init()
   ArrayDouble2d E, Dg, Dg2, C;
 

--- a/tick/optim/model/src/variants/hawkes_fixed_expkern_loglik_list.h
+++ b/tick/optim/model/src/variants/hawkes_fixed_expkern_loglik_list.h
@@ -12,7 +12,7 @@
  * exponential kernels with fixed exponent (i.e., alpha*beta*e^{-beta t}, with fixed beta)
  * on a list of realizations
  */
-class ModelHawkesFixedExpKernLogLikList : public ModelHawkesList {
+class DLL_PUBLIC ModelHawkesFixedExpKernLogLikList : public ModelHawkesList {
   //! @brief Value of decay for this model. Shared by all kernels
   double decay;
 

--- a/tick/optim/model/src/variants/hawkes_fixed_sumexpkern_leastsq_list.h
+++ b/tick/optim/model/src/variants/hawkes_fixed_sumexpkern_leastsq_list.h
@@ -12,7 +12,7 @@
  * \brief Class for computing L2 Contrast function and gradient for Hawkes processes with
  * exponential kernels with fixed exponent (i.e., alpha*beta*e^{-beta t}, with fixed beta)
  */
-class ModelHawkesFixedSumExpKernLeastSqList : public ModelHawkesLeastSqList {
+class DLL_PUBLIC ModelHawkesFixedSumExpKernLeastSqList : public ModelHawkesLeastSqList {
   //! @brief Some arrays used for intermediate computings.
   std::vector<ArrayDouble2d> E, Dgg, C;
   ArrayDouble2dList1D Dg;

--- a/tick/optim/model/src/variants/hawkes_leastsq_list.h
+++ b/tick/optim/model/src/variants/hawkes_leastsq_list.h
@@ -11,7 +11,7 @@
 /** \class ModelHawkesLeastSqList
  * \brief Base class of Hawkes models handling several realizations
  */
-class ModelHawkesLeastSqList : public ModelHawkesList {
+class DLL_PUBLIC ModelHawkesLeastSqList : public ModelHawkesList {
  protected:
   //! @brief Flag telling if precompations arrays have been allocated or not
   bool weights_allocated;

--- a/tick/optim/prox/src/prox.h
+++ b/tick/optim/prox/src/prox.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <string>
 
-class Prox {
+class DLL_PUBLIC Prox {
  protected:
   //! @brief Weight of the proximal operator
   double strength;

--- a/tick/optim/prox/src/prox_separable.h
+++ b/tick/optim/prox/src/prox_separable.h
@@ -5,7 +5,7 @@
 
 #include "prox.h"
 
-class ProxSeparable : public Prox {
+class DLL_PUBLIC ProxSeparable : public Prox {
  public:
   ProxSeparable(double strength, bool positive);
 

--- a/tick/optim/prox/src/prox_zero.h
+++ b/tick/optim/prox/src/prox_zero.h
@@ -5,7 +5,7 @@
 
 #include "prox_separable.h"
 
-class ProxZero : public ProxSeparable {
+class DLL_PUBLIC ProxZero : public ProxSeparable {
  public:
   explicit ProxZero(double strength);
 

--- a/tick/random/src/rand.cpp
+++ b/tick/random/src/rand.cpp
@@ -15,9 +15,6 @@
 //
 //
 
-
-#define _USE_MATH_DEFINES
-
 #include "rand.h"
 
 #include <iostream>

--- a/tick/random/src/rand.h
+++ b/tick/random/src/rand.h
@@ -21,7 +21,7 @@
  * Each instance wraps a Mersenne Twister random number generator and generate random probability
  * distributions from it.
  */
-class Rand {
+class DLL_PUBLIC Rand {
  private:
     int seed;
     std::mt19937_64 generator;


### PR DESCRIPTION
There's assumptions that MSVC is in use. 

Installing the requirements from pip is not so straight forward either and requires downloading some WHL files separately

```
numpy-1.13.1+mkl-cp36-cp36m-win_amd64.whl
numpydoc-0.7.0-py2.py3-none-any.whl
scipy-0.19.1-cp36-cp36m-win_amd64.whl
```

Which I got from here: www.lfd.uci.edu/~gohlke/pythonlibs

There's an issue linking libraries so it has to be done manually. 

I haven't tested linux and mac still work but I don't see why they wouldn't.

Feel free to reject and do manually.


Most notable change is probably in:
```
tick/base/src/interruption.h
```

As sharing static class members across DLLs is tricky, it's changed to a static method/member pair.

Prebuilt windows libraries can be found on the windows branch of my fork under the "build" directory.