### PR TITLE
TICK-373 Full sparse support in SVRG

### DIFF
--- a/tick/CMakeLists.txt
+++ b/tick/CMakeLists.txt
@@ -81,7 +81,7 @@ if (${GTEST_FOUND})
         ${TICK_BLAS_LIBRARIES})
 
     if(APPLE)
-        set(TICK_INSTALL_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/base/build;${CMAKE_CURRENT_SOURCE_DIR}/base/array/build;${CMAKE_CURRENT_SOURCE_DIR}/optim/model/build;${CMAKE_CURRENT_SOURCE_DIR}/random/build;${CMAKE_CURRENT_SOURCE_DIR}/simulation/build")
+        set(TICK_INSTALL_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/base/build;${CMAKE_CURRENT_SOURCE_DIR}/base/array/build;${CMAKE_CURRENT_SOURCE_DIR}/optim/model/build;${CMAKE_CURRENT_SOURCE_DIR}/random/build;${CMAKE_CURRENT_SOURCE_DIR}/optim/prox/build;${CMAKE_CURRENT_SOURCE_DIR}/optim/solver/build;${CMAKE_CURRENT_SOURCE_DIR}/simulation/build")
 
         set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
         set(CMAKE_INSTALL_RPATH "${TICK_INSTALL_RPATH}")
@@ -96,6 +96,7 @@ if (${GTEST_FOUND})
     add_subdirectory(base/tests/src)
     add_subdirectory(base/array/tests/src)
     add_subdirectory(optim/model/tests/src)
+    add_subdirectory(optim/solver/tests/src)
     add_subdirectory(simulation/tests/src)
 
     add_custom_target(check
@@ -104,6 +105,7 @@ if (${GTEST_FOUND})
             COMMAND base/array/tests/src/tick_test_varray
             COMMAND optim/model/tests/src/tick_test_model
             COMMAND simulation/tests/src/tick_test_hawkes
+            COMMAND optim/solver/tests/src/tick_test_solver
             )
 else()
     message(STATUS "Testing in C++ NOT enabled")

--- a/tick/optim/model/src/model_labels_features.cpp
+++ b/tick/optim/model/src/model_labels_features.cpp
@@ -1,9 +1,5 @@
 // License: BSD 3 clause
 
-//
-// Created by Stéphane GAIFFAS on 06/12/2015.
-//
-
 #include "model_labels_features.h"
 
 ModelLabelsFeatures::ModelLabelsFeatures(SBaseArrayDouble2dPtr features,
@@ -11,11 +7,32 @@ ModelLabelsFeatures::ModelLabelsFeatures(SBaseArrayDouble2dPtr features,
     : n_samples(labels.get() ? labels->size() : 0),
       n_features(features.get() ? features->n_cols() : 0),
       labels(labels),
-      features(features) {
+      features(features),
+      ready_columns_sparsity(false) {
   if (labels.get() && labels->size() != features->n_rows()) {
     std::stringstream ss;
     ss << "In ModelLabelsFeatures, number of labels is " << labels->size();
     ss << " while the features matrix has " << features->n_rows() << " rows.";
     throw std::invalid_argument(ss.str());
+  }
+}
+
+void ModelLabelsFeatures::compute_columns_sparsity() {
+  if (features->is_sparse()) {
+    column_sparsity = ArrayDouble(n_features);
+    column_sparsity.fill(0.);
+    for (ulong i = 0; i < n_samples; ++i) {
+      BaseArrayDouble features_i = get_features(i);
+      for (ulong j = 0; j < features_i.size_sparse(); ++j) {
+        // Even if the entry is zero (nothing forbids to store zeros...) increment
+        // the number of non-zeros of the columns. This is necessary when computed step-size corrections
+        // used in probabilistic updates (see SVRG::solve_sparse_proba_updates code for instance)
+        column_sparsity[features_i.indices()[j]] += 1;
+      }
+    }
+    column_sparsity.multiply(1. / n_samples);
+    ready_columns_sparsity = true;
+  } else {
+    TICK_ERROR("The features matrix is not sparse.")
   }
 }

--- a/tick/optim/model/src/model_labels_features.h
+++ b/tick/optim/model/src/model_labels_features.h
@@ -1,7 +1,3 @@
-//
-// Created by Stéphane GAIFFAS on 06/12/2015.
-//
-
 #ifndef TICK_OPTIM_MODEL_SRC_MODEL_LABELS_FEATURES_H_
 #define TICK_OPTIM_MODEL_SRC_MODEL_LABELS_FEATURES_H_
 
@@ -20,6 +16,9 @@ class ModelLabelsFeatures : public virtual Model {
 
   //! Features matrix (either sparse or not)
   SBaseArrayDouble2dPtr features;
+
+  bool ready_columns_sparsity;
+  ArrayDouble column_sparsity;
 
  public:
   ModelLabelsFeatures(SBaseArrayDouble2dPtr features,
@@ -54,9 +53,20 @@ class ModelLabelsFeatures : public virtual Model {
     return n_samples;
   }
 
+  bool is_ready_columns_sparsity() const {
+    return ready_columns_sparsity;
+  }
+
+  ArrayDouble get_column_sparsity_view() {
+    if (!is_ready_columns_sparsity()) compute_columns_sparsity();
+    return view(column_sparsity);
+  }
+
+  void compute_columns_sparsity();
+
   template<class Archive>
-  void load(Archive & ar) {
-    ar(CEREAL_NVP(n_samples) );
+  void load(Archive &ar) {
+    ar(CEREAL_NVP(n_samples));
 
     ArrayDouble temp_labels;
     ArrayDouble2d temp_features;
@@ -68,7 +78,7 @@ class ModelLabelsFeatures : public virtual Model {
   }
 
   template<class Archive>
-  void save(Archive & ar) const {
+  void save(Archive &ar) const {
     ar(CEREAL_NVP(n_samples));
     ar(cereal::make_nvp("labels", *labels));
     ar(cereal::make_nvp("features", *features));

--- a/tick/optim/model/swig/model.i
+++ b/tick/optim/model/swig/model.i
@@ -17,6 +17,8 @@ class Model {
   virtual double loss(const ArrayDouble& coeffs);
 
   virtual unsigned long get_epoch_size() const;
+
+  virtual bool is_sparse() const;
 };
 
 typedef std::shared_ptr<Model> ModelPtr;

--- a/tick/optim/prox/src/prox_elasticnet.h
+++ b/tick/optim/prox/src/prox_elasticnet.h
@@ -16,13 +16,14 @@ class ProxElasticNet : public ProxSeparable {
 
   const std::string get_class_name() const override;
 
-  double call_single(double x, double step) const override;
-
-  double value_single(double x) const override;
-
   virtual double get_ratio() const;
 
   virtual void set_ratio(double ratio);
+
+ private:
+  double call_single(double x, double step) const override;
+
+  double value_single(double x) const override;
 };
 
 #endif  // TICK_OPTIM_PROX_SRC_PROX_ELASTICNET_H_

--- a/tick/optim/prox/src/prox_l1.cpp
+++ b/tick/optim/prox/src/prox_l1.cpp
@@ -4,13 +4,13 @@
 
 ProxL1::ProxL1(double strength,
                bool positive)
-  : ProxSeparable(strength, positive) {}
+    : ProxSeparable(strength, positive) {}
 
 ProxL1::ProxL1(double strength,
                ulong start,
                ulong end,
                bool positive)
-  : ProxSeparable(strength, start, end, positive) {}
+    : ProxSeparable(strength, start, end, positive) {}
 
 const std::string ProxL1::get_class_name() const {
   return "ProxL1";

--- a/tick/optim/prox/src/prox_l1.h
+++ b/tick/optim/prox/src/prox_l1.h
@@ -13,6 +13,7 @@ class ProxL1 : public ProxSeparable {
 
   const std::string get_class_name() const override;
 
+ private:
   double call_single(double x, double step) const override;
 
   // Repeat n_times the prox on coordinate i

--- a/tick/optim/prox/src/prox_l1w.cpp
+++ b/tick/optim/prox/src/prox_l1w.cpp
@@ -5,7 +5,7 @@
 ProxL1w::ProxL1w(double strength,
                  SArrayDoublePtr weights,
                  bool positive)
-  : ProxSeparable(strength, positive) {
+    : ProxSeparable(strength, positive) {
   this->weights = weights;
 }
 
@@ -14,7 +14,7 @@ ProxL1w::ProxL1w(double strength,
                  ulong start,
                  ulong end,
                  bool positive)
-  : ProxSeparable(strength, start, end, positive) {
+    : ProxSeparable(strength, start, end, positive) {
   this->weights = weights;
 }
 
@@ -22,29 +22,91 @@ const std::string ProxL1w::get_class_name() const {
   return "ProxL1w";
 }
 
-void ProxL1w::call_single(ulong i,
-                          const ArrayDouble &coeffs,
-                          double step,
-                          ArrayDouble &out) const {
-  double thresh = step * strength;
-  double coeffs_i = coeffs[i];
-  double thresh_i = thresh * (*weights)[i];
-  if (coeffs_i > 0) {
-    if (coeffs_i > thresh_i) {
-      out[i] = coeffs_i - thresh_i;
+double ProxL1w::call_single(double x, double step) const {
+  TICK_CLASS_DOES_NOT_IMPLEMENT(get_class_name());
+}
+
+double ProxL1w::call_single(double x, double step, ulong n_times) const {
+  TICK_CLASS_DOES_NOT_IMPLEMENT(get_class_name());
+}
+
+double ProxL1w::value_single(double x) const {
+  TICK_CLASS_DOES_NOT_IMPLEMENT(get_class_name());
+}
+
+double ProxL1w::call_single(double x, double step, double weight) const {
+  double thresh = step * strength * weight;
+  if (x > 0) {
+    if (x > thresh) {
+      return x - thresh;
     } else {
-      out[i] = 0;
+      return 0;
     }
   } else {
     // If coeffs_i is negative we set it to 0
     if (positive) {
-      out[i] = 0;
+      return 0;
     } else {
-      if (coeffs_i < -thresh_i) {
-        out[i] = coeffs_i + thresh_i;
+      if (x < -thresh) {
+        return x + thresh;
       } else {
-        out[i] = 0;
+        return 0;
       }
+    }
+  }
+}
+
+double ProxL1w::call_single(double x, double step, double weight, ulong n_times) const {
+  if (n_times >= 1) {
+    return call_single(x, n_times * step, weight);
+  } else {
+    return x;
+  }
+}
+
+void ProxL1w::call(const ArrayDouble &coeffs,
+                   double step,
+                   ArrayDouble &out,
+                   ulong start,
+                   ulong end) {
+  ArrayDouble sub_coeffs = view(coeffs, start, end);
+  ArrayDouble sub_out = view(out, start, end);
+  for (ulong i = 0; i < sub_coeffs.size(); ++i) {
+    sub_out[i] = call_single(sub_coeffs[i], step, (*weights)[i]);
+  }
+}
+
+void ProxL1w::call(const ArrayDouble &coeffs,
+                   const ArrayDouble &step,
+                   ArrayDouble &out,
+                   ulong start,
+                   ulong end) {
+  ArrayDouble sub_coeffs = view(coeffs, start, end);
+  ArrayDouble sub_out = view(out, start, end);
+  for (ulong i = 0; i < sub_coeffs.size(); ++i) {
+    // weights has the same size as end - start, but not the step array
+    sub_out[i] = call_single(sub_coeffs[i], step[i + start], (*weights)[i]);
+  }
+}
+
+// We cannot implement only ProxL1w::call_single(double x, double step) since we need to
+// know i to find the weight
+void ProxL1w::call_single(ulong i,
+                          const ArrayDouble &coeffs,
+                          double step,
+                          ArrayDouble &out) const {
+  if (i >= coeffs.size()) {
+    TICK_ERROR(get_class_name() << "::call_single " << "i= " << i
+                                << " while coeffs.size()=" << coeffs.size());
+  } else {
+    if (has_range) {
+      if ((i >= start) && (i < end)) {
+        out[i] = call_single(coeffs[i], step, (*weights)[i - start]);
+      } else {
+        out[i] = coeffs[i];
+      }
+    } else {
+      out[i] = call_single(coeffs[i], step, (*weights)[i - start]);
     }
   }
 }
@@ -54,14 +116,33 @@ void ProxL1w::call_single(ulong i,
                           double step,
                           ArrayDouble &out,
                           ulong n_times) const {
-  if (n_times >= 1) {
-    call_single(i, coeffs, n_times * step, out);
+  if (i >= coeffs.size()) {
+    TICK_ERROR(get_class_name() << "::call_single " << "i= " << i
+                                << " while coeffs.size()=" << coeffs.size());
   } else {
-    out[i] = coeffs[i];
+    if (has_range) {
+      if ((i >= start) && (i < end)) {
+        out[i] = call_single(coeffs[i], step, (*weights)[i - start], n_times);
+      } else {
+        out[i] = coeffs[i];
+      }
+    } else {
+      out[i] = call_single(coeffs[i], step, (*weights)[i - start], n_times);
+    }
   }
 }
 
-double ProxL1w::value_single(ulong i,
-                             const ArrayDouble &coeffs) const {
-  return (*weights)[i] * std::abs(coeffs[i]);
+double ProxL1w::value_single(double x, double weight) const {
+  return weight * std::abs(x);
+}
+
+double ProxL1w::value(const ArrayDouble &coeffs, ulong start, ulong end) {
+  double val = 0;
+  // We work on a view, so that sub_coeffs and weights are "aligned"
+  // (namely both ranging between 0 and end - start).
+  ArrayDouble sub_coeffs = view(coeffs, start, end);
+  for (ulong i = 0; i < sub_coeffs.size(); ++i) {
+    val += value_single(sub_coeffs[i], (*weights)[i]);
+  }
+  return strength * val;
 }

--- a/tick/optim/prox/src/prox_l1w.h
+++ b/tick/optim/prox/src/prox_l1w.h
@@ -18,6 +18,12 @@ class ProxL1w : public ProxSeparable {
 
   const std::string get_class_name() const override;
 
+  void call(const ArrayDouble &coeffs, const double step, ArrayDouble &out,
+            ulong start, ulong end) override;
+
+  void call(const ArrayDouble &coeffs, const ArrayDouble &step, ArrayDouble &out,
+            ulong start, ulong end) override;
+
   // For this prox we cannot only override double call_single(double, step) const,
   // since we need the weights...
   void call_single(ulong i, const ArrayDouble &coeffs, double step,
@@ -26,12 +32,24 @@ class ProxL1w : public ProxSeparable {
   void call_single(ulong i, const ArrayDouble &coeffs, double step,
                    ArrayDouble &out, ulong n_times) const override;
 
-  double value_single(ulong i,
-                      const ArrayDouble &coeffs) const override;
+  double value(const ArrayDouble &coeffs, ulong start, ulong end) override;
 
   void set_weights(SArrayDoublePtr weights) {
     this->weights = weights;
   }
+
+ private:
+  double call_single(double x, double step) const override;
+
+  double call_single(double x, double step, ulong n_times) const override;
+
+  double value_single(double x) const override;
+
+  double call_single(double x, double step, double weight) const;
+
+  double call_single(double x, double step, double weight, ulong n_times) const;
+
+  double value_single(double x, double weight) const;
 };
 
 #endif  // TICK_OPTIM_PROX_SRC_PROX_L1W_H_

--- a/tick/optim/prox/src/prox_l2sq.h
+++ b/tick/optim/prox/src/prox_l2sq.h
@@ -13,6 +13,7 @@ class ProxL2Sq : public ProxSeparable {
 
   const std::string get_class_name() const override;
 
+ private:
   double value_single(double x) const override;
 
   double call_single(double x, double step) const override;

--- a/tick/optim/prox/src/prox_positive.h
+++ b/tick/optim/prox/src/prox_positive.h
@@ -13,13 +13,14 @@ class ProxPositive : public ProxSeparable {
 
   const std::string get_class_name() const override;
 
+  // Override value, only this value method should be called
+  double value(const ArrayDouble &coeffs, ulong start, ulong end) override;
+
+ private:
   double call_single(double x, double step) const override;
 
   // Repeat n_times the prox on coordinate i
   double call_single(double x, double step, ulong n_times) const override;
-
-  // Override value, only this value method should be called
-  double value(const ArrayDouble &coeffs, ulong start, ulong end) override;
 };
 
 #endif  // TICK_OPTIM_PROX_SRC_PROX_POSITIVE_H_

--- a/tick/optim/prox/src/prox_separable.h
+++ b/tick/optim/prox/src/prox_separable.h
@@ -30,12 +30,6 @@ class ProxSeparable : public Prox {
   virtual void call(const ArrayDouble &coeffs, const ArrayDouble &step, ArrayDouble &out,
                     ulong start, ulong end);
 
-  //! @brief apply prox on a single value
-  virtual double call_single(double x, double step) const;
-
-  //! @brief apply prox on a single value several times
-  virtual double call_single(double x, double step, ulong n_times) const;
-
   //! @brief apply prox on a single value defined by coordinate i
   virtual void call_single(ulong i, const ArrayDouble &coeffs, double step,
                            ArrayDouble &out) const;
@@ -46,9 +40,12 @@ class ProxSeparable : public Prox {
 
   double value(const ArrayDouble &coeffs, ulong start, ulong end) override;
 
-  //! @brief get penalization value of the prox on a single value defined by coordinate i
-  //! @warning This does not take strength into account
-  virtual double value_single(ulong i, const ArrayDouble &coeffs) const;
+ private:
+  //! @brief apply prox on a single value
+  virtual double call_single(double x, double step) const;
+
+  //! @brief apply prox on a single value several times
+  virtual double call_single(double x, double step, ulong n_times) const;
 
   //! @brief get penalization value of the prox on a single value
   //! @warning This does not take strength into account

--- a/tick/optim/prox/src/prox_zero.h
+++ b/tick/optim/prox/src/prox_zero.h
@@ -15,11 +15,12 @@ class ProxZero : public ProxSeparable {
 
   const std::string get_class_name() const override;
 
+  double value(const ArrayDouble &coeffs, ulong start, ulong end) override;
+
+ private:
   double call_single(double x, double step) const override;
 
   double call_single(double x, double step, ulong n_times) const override;
-
-  double value(const ArrayDouble &coeffs, ulong start, ulong end) override;
 };
 
 #endif  // TICK_OPTIM_PROX_SRC_PROX_ZERO_H_

--- a/tick/optim/prox/tests/prox_l1w_test.py
+++ b/tick/optim/prox/tests/prox_l1w_test.py
@@ -11,7 +11,7 @@ from tick.optim.prox.tests.prox import TestProx
 
 class Test(TestProx):
     def test_ProxL1w(self):
-        """...Test of ProxL1
+        """...Test of test_ProxL1w
         """
         coeffs = self.coeffs.copy()
 

--- a/tick/optim/prox/tests/prox_l2sq_test.py
+++ b/tick/optim/prox/tests/prox_l2sq_test.py
@@ -49,8 +49,6 @@ class Test(TestProx):
         out = coeffs.copy()
         t = np.linspace(1, 10, 5)
         out[3:8] *= 1. / (1. + t * l_l2sq)
-        # idx = out[3:8] < 0
-        # out[3:8][idx] = 0
         self.assertAlmostEqual(prox.value(coeffs),
                                0.5 * l_l2sq * norm(coeffs[3:8]) ** 2.,
                                delta=1e-15)

--- a/tick/optim/solver/src/svrg.h
+++ b/tick/optim/solver/src/svrg.h
@@ -1,7 +1,3 @@
-//
-// Created by Martin Bompaire on 23/10/15.
-//
-
 #ifndef TICK_OPTIM_SOLVER_SRC_SVRG_H_
 #define TICK_OPTIM_SOLVER_SRC_SVRG_H_
 
@@ -10,49 +6,70 @@
 #include "array.h"
 #include "sgd.h"
 #include "../../prox/src/prox.h"
+#include "../../prox/src/prox_separable.h"
 
 class SVRG : public StoSolver {
  public:
-    enum class VarianceReductionMethod {
-        Last    = 1,
-        Average = 2,
-        Random  = 3,
-    };
+  enum class VarianceReductionMethod {
+    Last = 1,
+    Average = 2,
+    Random = 3,
+  };
 
  private:
-    double step;
-    VarianceReductionMethod variance_reduction;
-    ArrayDouble next_iterate;
+  double step;
+  // Probabilistic correction of the step-sizes of all model weights,
+  // given by the inverse proportion of non-zero entries in each feature column
+  ArrayDouble steps_correction;
+
+  VarianceReductionMethod variance_reduction;
+
+  ArrayDouble full_gradient;
+  ArrayDouble fixed_w;
+  ArrayDouble grad_i;
+  ArrayDouble grad_i_fixed_w;
+  ArrayDouble next_iterate;
+
+  ulong rand_index;
+  bool ready_step_corrections;
+
+  void prepare_solve();
+
+  void solve_dense();
+
+  void solve_sparse_proba_updates(bool use_intercept, ulong n_features);
+
+  void compute_step_corrections();
 
  public:
-    SVRG(ulong epoch_size,
-         double tol,
-         RandType rand_type,
-         double step,
-         int seed = -1,
-         VarianceReductionMethod variance_reduction = VarianceReductionMethod::Last);
+  SVRG(ulong epoch_size,
+       double tol,
+       RandType rand_type,
+       double step,
+       int seed = -1,
+       VarianceReductionMethod variance_reduction = VarianceReductionMethod::Last);
 
-    void solve() override;
+  void solve() override;
 
-    double get_step() const {
-        return step;
-    }
+  void set_model(ModelPtr model) override;
 
-    void set_step(double step) {
-        SVRG::step = step;
-    }
+  double get_step() const {
+    return step;
+  }
 
-    VarianceReductionMethod get_variance_reduction() const {
-        return variance_reduction;
-    }
+  void set_step(double step) {
+    SVRG::step = step;
+  }
 
-    void set_variance_reduction(VarianceReductionMethod variance_reduction) {
-        SVRG::variance_reduction = variance_reduction;
-    }
+  VarianceReductionMethod get_variance_reduction() const {
+    return variance_reduction;
+  }
 
-    void set_starting_iterate(ArrayDouble &new_iterate) override;
+  void set_variance_reduction(VarianceReductionMethod variance_reduction) {
+    SVRG::variance_reduction = variance_reduction;
+  }
 
-    void solve_sparse();
+  void set_starting_iterate(ArrayDouble &new_iterate) override;
 };
 
 #endif  // TICK_OPTIM_SOLVER_SRC_SVRG_H_

--- a/tick/optim/solver/swig/svrg.i
+++ b/tick/optim/solver/swig/svrg.i
@@ -8,8 +8,7 @@
 %}
 
 class SVRG : public StoSolver {
-
-public:
+  public:
     enum class VarianceReductionMethod {
         Last    = 1,
         Average = 2,

--- a/tick/optim/solver/tests/src/CMakeLists.txt
+++ b/tick/optim/solver/tests/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(tick_test_solver test_svrg.cpp)
+
+target_link_libraries(tick_test_solver
+    ${TICK_LIB_ARRAY}
+    ${TICK_LIB_BASE}
+    ${TICK_LIB_MODEL}
+    ${TICK_LIB_PROX}
+    ${TICK_LIB_CRANDOM}
+    ${TICK_LIB_SOLVER}
+    ${TICK_TEST_LIBS}
+    )

--- a/tick/optim/solver/tests/src/test_svrg.cpp
+++ b/tick/optim/solver/tests/src/test_svrg.cpp
@@ -1,0 +1,76 @@
+#define DEBUG_COSTLY_THROW 1
+
+#include <gtest/gtest.h>
+#include <svrg.h>
+#include <prox_l2sq.h>
+#include <prox_l2sq.h>
+#include "linreg.h"
+
+SArrayDoublePtr get_labels() {
+  ArrayDouble labels{-1.76, 2.6, -0.7, -1.84, -1.88, -1.78, 2.52};
+  return labels.as_sarray_ptr();
+}
+
+SArrayDouble2dPtr get_features() {
+  ulong n_samples = 7;
+  ulong n_features = 5;
+
+  ArrayDouble features_data{0.55, 2.04, 0.78, -0.00, 0.00,
+                            -0.00, -2.62, -0.00, 0.00, 0.31,
+                            -0.64, 0.94, 0.00, 0.55, -0.14,
+                            0.93, 0.00, 0.00, -0.00, -2.39,
+                            1.13, 0.05, -1.50, -0.50, -1.41,
+                            1.41, 1.10, -0.00, 0.12, 0.00,
+                            -0.00, -1.33, -0.00, 0.85, 3.03};
+
+  ArrayDouble2d features(n_samples, n_features);
+  for (int i = 0; i < features_data.size(); ++i) {
+    features[i] = features_data[i];
+  }
+  return features.as_sarray2d_ptr();
+}
+
+SSparseArrayDouble2dPtr get_sparse_features() {
+  ulong n_samples = 7;
+  ulong n_features = 5;
+  // no need to free, it will be done by sparse array
+  double* sparse_data = new double[22]{0.55, 2.04, 0.78, -2.62, 0.31, -0.64, 0.94, 0.55, -0.14, 0.93, -2.39,
+                                       1.13, 0.05, -1.50, -0.50, -1.41, 1.41, 1.10, 0.12, -1.33, 0.85, 3.03};
+  INDICE_TYPE* sparse_indices = new INDICE_TYPE[22] {0, 1, 2, 1, 4, 0, 1, 3, 4, 0, 4, 0, 1, 2, 3,
+                                                     4, 0, 1, 3, 1, 3, 4};
+  INDICE_TYPE* sparse_indptr = new INDICE_TYPE[8] {0, 3, 5, 9, 11, 16, 19, 22};
+
+  SSparseArrayDouble2dPtr sparse_features = SSparseArrayDouble2d::new_ptr(0, 0, 0);
+  sparse_features->set_data_indices_rowindices(sparse_data, sparse_indices, sparse_indptr,
+                                               n_samples, n_features);
+  return sparse_features;
+}
+
+TEST(SVRG, test_convergence) {
+  SArrayDoublePtr labels_ptr = get_labels();
+  SArrayDouble2dPtr features_ptr = get_features();
+
+  ulong n_samples = features_ptr->n_rows();
+  ulong n_features = features_ptr->n_cols();
+
+  auto model = std::make_shared<ModelLinReg>(features_ptr, labels_ptr, false, 1);
+  SVRG svrg(n_samples, 0, RandType::unif, model->get_lip_max() / 100, 1309);
+  svrg.set_rand_max(n_samples);
+  svrg.set_model(model);
+  svrg.set_prox(std::make_shared<ProxL2Sq>(1e-3, false));
+
+  ArrayDouble out_iterate30(n_features);
+  for (int j = 0; j < 30; ++j) {
+    svrg.solve();
+  }
+  svrg.get_iterate(out_iterate30);
+
+  ArrayDouble out_iterate60(n_features);
+  for (int j = 0; j < 30; ++j) {
+    svrg.solve();
+  }
+  svrg.get_iterate(out_iterate60);
+
+  out_iterate60.mult_incr(out_iterate30, -1);
+  EXPECT_LE(out_iterate60.norm_sq() / n_features, 0.1);
+}

--- a/tick/optim/solver/tests/svrg_test.py
+++ b/tick/optim/solver/tests/svrg_test.py
@@ -1,6 +1,17 @@
 # License: BSD 3 clause
 
 import unittest
+from warnings import catch_warnings, simplefilter
+from itertools import product
+
+import numpy as np
+from scipy.linalg.special_matrices import toeplitz
+from scipy.sparse import csr_matrix
+
+from tick.optim.model import ModelLinReg
+
+from tick.optim.prox import ProxL1, ProxL1w, ProxTV, ProxEquality, \
+    ProxElasticNet
 
 from tick.optim.solver import SVRG
 from tick.optim.solver.tests.solver import TestSolver
@@ -8,6 +19,32 @@ from tick.optim.solver.build.solver import SVRG as _SVRG
 
 
 class Test(TestSolver):
+    @staticmethod
+    def simu_linreg_data(n_samples=5000, n_features=50, interc=-1., p_nnz=0.3):
+        np.random.seed(123)
+        idx = np.arange(1, n_features + 1)
+        weights = (-1) ** (idx - 1) * np.exp(-idx / 10.)
+        corr = 0.5
+        cov = toeplitz(corr ** np.arange(0, n_features))
+        X = np.random.multivariate_normal(np.zeros(n_features), cov,
+                                          size=n_samples)
+        X *= np.random.binomial(1, p_nnz, size=X.shape)
+        idx = np.nonzero(X.sum(axis=1))
+        X = X[idx]
+        n_samples = X.shape[0]
+        noise = np.random.randn(n_samples)
+        y = X.dot(weights) + noise
+        if interc:
+            y += interc
+        return X, y
+
+    @staticmethod
+    def get_dense_and_sparse_linreg_model(X_dense, y, fit_intercept=True):
+        X_sparse = csr_matrix(X_dense)
+        model_dense = ModelLinReg(fit_intercept).fit(X_dense, y)
+        model_spars = ModelLinReg(fit_intercept).fit(X_sparse, y)
+        return model_dense, model_spars
+
     def test_solver_svrg(self):
         """...Check SVRG solver for a Logistic Regression with Ridge
         penalization
@@ -27,7 +64,7 @@ class Test(TestSolver):
         self._test_solver_sparse_and_dense_consistency(create_solver)
 
     def test_variance_reduction_setting(self):
-        """...Test SVRG variance_reduction parameter is correctly set
+        """...Test that SVRG variance_reduction parameter behaves correctly
         """
         svrg = SVRG()
         self.assertEqual(svrg.variance_reduction, 'last')
@@ -54,8 +91,106 @@ class Test(TestSolver):
         self.assertEqual(svrg._solver.get_variance_reduction(),
                          _SVRG.VarianceReductionMethod_Last)
 
-        with self.assertRaises(ValueError):
-            svrg.variance_reduction = 'wrong_name'
+        msg = '^variance_reduction should be one of "avg, last, rand", ' \
+              'got "stuff"$'
+        with self.assertRaisesRegex(ValueError, msg):
+            svrg = SVRG(variance_reduction='stuff')
+        with self.assertRaisesRegex(ValueError, msg):
+            svrg.variance_reduction = 'stuff'
+
+        X, y = self.simu_linreg_data()
+        model_dense, model_spars = self.get_dense_and_sparse_linreg_model(X, y)
+        try:
+            svrg.set_model(model_dense)
+            svrg.variance_reduction = 'avg'
+            svrg.variance_reduction = 'last'
+            svrg.variance_reduction = 'rand'
+            svrg.set_model(model_spars)
+            svrg.variance_reduction = 'last'
+            svrg.variance_reduction = 'rand'
+        except Exception:
+            self.fail('Setting variance_reduction in these cases should have '
+                      'been ok')
+
+        msg = "'avg' variance reduction cannot be used with sparse datasets"
+        with catch_warnings(record=True) as w:
+            simplefilter('always')
+            svrg.set_model(model_spars)
+            svrg.variance_reduction = 'avg'
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, UserWarning))
+            self.assertEqual(str(w[0].message), msg)
+
+    def test_set_model(self):
+        """...Test SVRG set_model
+        """
+        X, y = self.simu_linreg_data()
+        _, model_spars = self.get_dense_and_sparse_linreg_model(X, y)
+        svrg = SVRG(variance_reduction='avg')
+        msg = "'avg' variance reduction cannot be used with sparse datasets. " \
+              "Please change `variance_reduction` before passing sparse data."
+        with catch_warnings(record=True) as w:
+            simplefilter('always')
+
+            svrg.set_model(model_spars)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, UserWarning))
+            self.assertEqual(str(w[0].message), msg)
+
+    def test_dense_and_sparse_match(self):
+        """...Test in SVRG that dense and sparse code matches in all possible
+        settings
+        """
+        variance_reductions = ['last', 'rand']
+        rand_types = ['perm', 'unif']
+        seed = 123
+        tol = 0.
+        max_iter = 50
+
+        n_samples = 500
+        n_features = 20
+
+        # Crazy prox examples
+        proxs = [
+            ProxTV(strength=1e-2, range=(5, 13), positive=True),
+            ProxElasticNet(strength=1e-2, ratio=0.9),
+            ProxEquality(range=(0, n_features)),
+            ProxL1(strength=1e-3, range=(5, 17)),
+            ProxL1w(strength=1e-3, weights=np.arange(5, 17, dtype=np.double),
+                    range=(5, 17)),
+        ]
+
+        for intercept in [-1, None]:
+            X, y = self.simu_linreg_data(interc=intercept,
+                                         n_features=n_features,
+                                         n_samples=n_samples)
+
+            fit_intercept = intercept is not None
+            model_dense, model_spars = self.get_dense_and_sparse_linreg_model(
+                    X, y, fit_intercept=fit_intercept)
+            step = 1 / model_spars.get_lip_max()
+
+            for variance_reduction, rand_type, prox in product(
+                    variance_reductions, rand_types, proxs):
+                solver_sparse = SVRG(step=step, tol=tol, max_iter=max_iter,
+                                     verbose=False,
+                                     variance_reduction=variance_reduction,
+                                     rand_type=rand_type, seed=seed) \
+                    .set_model(model_spars) \
+                    .set_prox(prox)
+
+                solver_dense = SVRG(step=step, tol=tol, max_iter=max_iter,
+                                    verbose=False,
+                                    variance_reduction=variance_reduction,
+                                    rand_type=rand_type, seed=seed) \
+                    .set_model(model_dense) \
+                    .set_prox(prox)
+
+                solver_sparse.solve()
+                solver_dense.solve()
+                np.testing.assert_array_almost_equal(solver_sparse.solution,
+                                                     solver_dense.solution, 7)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Strong improvement of SVRG for sparse data, this adds :
* Fully sparse updates in the case of sparse data, when the prox is separable. 

For now, SVRG only supports the so-called 'probabilistic' approach, where a correction of the step-sizes is used for each feature.
The exact updates, based on delayed computations, will be added in a future version.