### PR TITLE
TICK-412 Corrects things with ModelLinRegWithOutliers and RobustLinearRegression 

### DIFF
--- a/tick/inference/base/learner_robust_glm.py
+++ b/tick/inference/base/learner_robust_glm.py
@@ -205,8 +205,11 @@ class LearnerRobustGLM(LearnerGLM):
             self.step = 1. / model_obj.get_lip_best()
 
         # Range of the sample intercepts prox is always the same
-        prox_intercepts_obj.range = (n_features, n_features + n_samples)
-
+        if fit_intercept:
+            prox_intercepts_obj.range = (n_features + 1,
+                                         n_features + n_samples + 1)
+        else:
+            prox_intercepts_obj.range = (n_features, n_features + n_samples)
         prox_obj.range = (0, n_features)
 
         if self.penalty == 'none':
@@ -234,13 +237,14 @@ class LearnerRobustGLM(LearnerGLM):
 
         self._set("coeffs", coeffs)
         self._set("weights", coeffs[:n_features])
-        self._set("sample_intercepts",
-                  coeffs[n_features:(n_features + n_samples)])
         if fit_intercept:
-            self._set("intercept", coeffs[-1])
+            self._set("intercept", coeffs[n_features])
+            self._set("sample_intercepts",
+                      coeffs[(n_features + 1):(n_features + n_samples + 1)])
         else:
             self._set("intercept", None)
-
+            self._set("sample_intercepts",
+                      coeffs[n_features:(n_features + n_samples)])
         self._set("_fitted", True)
         return self
 

--- a/tick/inference/robust_linear_regression.py
+++ b/tick/inference/robust_linear_regression.py
@@ -113,7 +113,7 @@ class RobustLinearRegression(LearnerRobustGLM):
     def __init__(self, C_sample_intercepts, C=1e3, fdr=0.05,
                  penalty='l2', fit_intercept=True, refit=False,
                  solver='agd', warm_start=False, step=None,
-                 tol=1e-5, max_iter=100,
+                 tol=1e-7, max_iter=200,
                  verbose=True, print_every=10,
                  record_every=10,
                  elastic_net_ratio=0.95, slope_fdr=0.05):

--- a/tick/optim/model/tests/linreg_test.py
+++ b/tick/optim/model/tests/linreg_test.py
@@ -15,7 +15,6 @@ class Test(TestGLM):
         """...Numerical consistency check of loss and gradient for Linear
         Regression
         """
-
         np.random.seed(12)
         n_samples, n_features = 5000, 10
         w0 = np.random.randn(n_features)
@@ -28,6 +27,7 @@ class Test(TestGLM):
         model = ModelLinReg(fit_intercept=True).fit(X, y)
         model_spars = ModelLinReg(fit_intercept=True).fit(X_spars, y)
         self.run_test_for_glm(model, model_spars, 1e-5, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         # Then check without intercept
         X, y = SimuLinReg(w0, None, n_samples=n_samples,
@@ -37,6 +37,7 @@ class Test(TestGLM):
 
         model_spars = ModelLinReg(fit_intercept=False).fit(X_spars, y)
         self.run_test_for_glm(model, model_spars, 1e-5, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         # Test for the Lipschitz constants without intercept
         self.assertAlmostEqual(model.get_lip_best(), 2.6873683857125981)

--- a/tick/optim/model/tests/linreg_with_intercepts_test.py
+++ b/tick/optim/model/tests/linreg_with_intercepts_test.py
@@ -12,28 +12,97 @@ from tick.simulation.base.weights import weights_sparse_gauss
 
 
 class Test(TestGLM):
-    def test_ModelLinRegWithIntercepts(self):
-        """...Numerical consistency check of loss and gradient for Linear
-        Regression
+    def test_ModelLinRegWithInterceptsWithGlobalIntercept(self):
+        """...Numerical consistency check of loss and gradient for linear
+        regression with sample intercepts and a global intercept
         """
-
         np.random.seed(12)
         n_samples, n_features = 200, 5
         w0 = np.random.randn(n_features)
         intercept0 = 50 * weights_sparse_gauss(n_weights=n_samples, nnz=30)
-        X, y = SimuLinReg(w0, None, n_samples=n_samples,
-                          verbose=False, seed=2038).simulate()
+        c0 = None
+        X, y = SimuLinReg(w0, c0, n_samples=n_samples, verbose=False,
+                          seed=2038).simulate()
         # Add gross outliers to the labels
         y += intercept0
         X_spars = csr_matrix(X)
-        model = ModelLinRegWithIntercepts().fit(X, y)
-        model_spars = ModelLinRegWithIntercepts().fit(X_spars, y)
+        model = ModelLinRegWithIntercepts(fit_intercept=False).fit(X, y)
+        model_spars = ModelLinRegWithIntercepts(fit_intercept=False) \
+            .fit(X_spars, y)
         self.run_test_for_glm(model, model_spars, 1e-4, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         self.assertAlmostEqual(model.get_lip_mean(), 6.324960325598532)
         self.assertAlmostEqual(model.get_lip_max(), 30.277118951892113)
         self.assertAlmostEqual(model.get_lip_mean(), model_spars.get_lip_mean())
         self.assertAlmostEqual(model.get_lip_max(), model_spars.get_lip_max())
+        self.assertAlmostEqual(model.get_lip_best(), 2.7217793249045439)
+
+    def test_ModelLinRegWithInterceptsWithoutGlobalIntercept(self):
+        """...Numerical consistency check of loss and gradient for linear
+        regression with sample intercepts and no global intercept
+        """
+        np.random.seed(12)
+        n_samples, n_features = 200, 5
+        w0 = np.random.randn(n_features)
+        intercept0 = 50 * weights_sparse_gauss(n_weights=n_samples, nnz=30)
+        c0 = None
+        X, y = SimuLinReg(w0, c0, n_samples=n_samples, verbose=False,
+                          seed=2038).simulate()
+        # Add gross outliers to the labels
+        y += intercept0
+        X_spars = csr_matrix(X)
+        model = ModelLinRegWithIntercepts(fit_intercept=True).fit(X, y)
+        model_spars = ModelLinRegWithIntercepts(fit_intercept=True) \
+            .fit(X_spars, y)
+        self.run_test_for_glm(model, model_spars, 1e-4, 1e-4)
+
+        self.assertAlmostEqual(model.get_lip_mean(), 7.324960325598536)
+        self.assertAlmostEqual(model.get_lip_max(), 31.277118951892113)
+        self.assertAlmostEqual(model.get_lip_mean(), model_spars.get_lip_mean())
+        self.assertAlmostEqual(model.get_lip_max(), model_spars.get_lip_max())
+        self.assertAlmostEqual(model.get_lip_best(), 2.7267793249045438)
+
+    def test_ModelLinRegWithInterceptsWithoutGlobalInterceptExtras(self):
+        """...Extra tests for linear regression with sample intercepts and not
+        global intercept, check gradient wrt homemade gradient
+        """
+        np.random.seed(12)
+        n_samples, n_features = 200, 5
+        w0 = np.random.randn(n_features)
+        intercept0 = 50 * weights_sparse_gauss(n_weights=n_samples, nnz=30)
+        c0 = None
+        X, y = SimuLinReg(w0, c0, n_samples=n_samples, verbose=False,
+                          seed=2038).simulate()
+        # Add gross outliers to the labels
+        y += intercept0
+        model = ModelLinRegWithIntercepts(fit_intercept=False).fit(X, y)
+        coeffs = np.random.randn(model.n_coeffs)
+        grad1 = model.grad(coeffs)
+        X2 = np.hstack((X, np.identity(n_samples)))
+        grad2 = X2.T.dot(X2.dot(coeffs) - y) / n_samples
+        np.testing.assert_almost_equal(grad1, grad2, decimal=10)
+
+    def test_ModelLinRegWithInterceptsWithGlobalInterceptExtras(self):
+        """...Extra tests for linear regression with sample intercepts and
+        global intercept, check gradient wrt homemade gradient
+        """
+        np.random.seed(12)
+        n_samples, n_features = 200, 5
+        w0 = np.random.randn(n_features)
+        intercept0 = 50 * weights_sparse_gauss(n_weights=n_samples, nnz=30)
+        c0 = -1.
+        X, y = SimuLinReg(w0, c0, n_samples=n_samples, verbose=False,
+                          seed=2038).simulate()
+        # Add gross outliers to the labels
+        y += intercept0
+        model = ModelLinRegWithIntercepts(fit_intercept=True).fit(X, y)
+        coeffs = np.random.randn(model.n_coeffs)
+        grad1 = model.grad(coeffs)
+        X2 = np.hstack((X, np.ones((n_samples, 1)), np.identity(n_samples)))
+        grad2 = X2.T.dot(X2.dot(coeffs) - y) / n_samples
+        np.testing.assert_almost_equal(grad1, grad2, decimal=10)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tick/optim/model/tests/logreg_test.py
+++ b/tick/optim/model/tests/logreg_test.py
@@ -28,6 +28,7 @@ class Test(TestGLM):
         model = ModelLogReg(fit_intercept=True).fit(X, y)
         model_spars = ModelLogReg(fit_intercept=True).fit(X_spars, y)
         self.run_test_for_glm(model, model_spars, 1e-5, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         # Then check without intercept
         X, y = SimuLogReg(w0, None, n_samples=n_samples,
@@ -37,6 +38,7 @@ class Test(TestGLM):
 
         model_spars = ModelLogReg(fit_intercept=False).fit(X_spars, y)
         self.run_test_for_glm(model, model_spars, 1e-5, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         # Test for the Lipschitz constants without intercept
         self.assertAlmostEqual(model.get_lip_best(), 0.67184209642814952)

--- a/tick/optim/model/tests/poisreg_test.py
+++ b/tick/optim/model/tests/poisreg_test.py
@@ -31,6 +31,7 @@ class Test(TestGLM):
         model = ModelPoisReg(fit_intercept=True).fit(X, y)
         model_sparse = ModelPoisReg(fit_intercept=True).fit(X_spars, y)
         self.run_test_for_glm(model, model_sparse, 1e-3, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         # Then check without intercept
         X, y = SimuPoisReg(w0, None, n_samples=n_samples,
@@ -40,6 +41,7 @@ class Test(TestGLM):
         model = ModelPoisReg(fit_intercept=False).fit(X, y)
         model_sparse = ModelPoisReg(fit_intercept=False).fit(X_spars, y)
         self.run_test_for_glm(model, model_sparse, 1e-3, 1e-4)
+        self._test_glm_intercept_vs_hardcoded_intercept(model)
 
         # Test the self-concordance constant
         n_samples, n_features = 5, 2


### PR DESCRIPTION
Corrects computations in ModelLinRegWithOutliers (global intercept is correctly positioned now), adds many unittests and corrected RobustLinearRegression as well (and added unittests). Adds also a unittest for GLM models that checks computations with intercept and without with hard-coded intercept
