### PR TITLE
#80 Fix unittest for Hawkes hessian

### DIFF
--- a/tick/optim/model/tests/hawkes_fixed_expkern_loglik_test.py
+++ b/tick/optim/model/tests/hawkes_fixed_expkern_loglik_test.py
@@ -180,9 +180,8 @@ class Test(unittest.TestCase):
         for model in [self.model]:
             hessian = model.hessian(self.coeffs).todense()
             # Check that hessian is equal to its transpose
-            np.testing.assert_array_equal(hessian, hessian.T)
-
-            np.set_printoptions(precision=3, linewidth=200)
+            np.testing.assert_array_almost_equal(hessian, hessian.T,
+                                                 decimal=10)
 
             # Check that for all dimension hessian row is consistent
             # with its corresponding gradient coordinate.


### PR DESCRIPTION
It was just a check that hessian was equal to its transpose that was not verified at a very high precision (10^-16)