### PR TITLE
#82 Temporary fix: Removing -Werror

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -287,7 +287,9 @@ def create_extension(extension_name, module_dir,
 
     # Added -Wall to get all warnings and -Werror to treat them as errors
     extra_compile_args.append("-Wall")
-    extra_compile_args.append("-Werror")
+    # GITHUB ISSUE: 82 - temporary fix to avoid compile errors from
+    #  warnings given in CEREAL files
+    #extra_compile_args.append("-Werror")
 
     # This warning is turned off because SWIG generates files that triggers the
     # warning


### PR DESCRIPTION
 as CEREAL has unused members that cause compile error with -Wall and -Werror - to be fixed properly and re-add -Werror when proper resolution is found