### PR TITLE
#150 GCC 4.x - system_error not in namespace std

### DIFF
--- a/lib/swig/array/array_module.i
+++ b/lib/swig/array/array_module.i
@@ -6,6 +6,7 @@
 %import defs.i
 
 %{
+#include <system_error>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"
 #include "tick/base/debug.h"


### PR DESCRIPTION
Referencing #150 