### PR TITLE
Add ConvSCCS model + refactoring of SCCS-related stuff (preprocessing, simulations, etc.)

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -43,3 +43,4 @@ similar API to scikit-learn preprocessors.
 
    LongitudinalFeaturesProduct
    LongitudinalFeaturesLagger
+   LongitudinalSamplesFilter

--- a/doc/modules/survival.rst
+++ b/doc/modules/survival.rst
@@ -25,6 +25,7 @@ Kaplan-Meier estimators.
    CoxRegression
    nelson_aalen
    kaplan_meier
+   ConvSCCS
 
 2. Models
 =========

--- a/doc/modules/survival.rst
+++ b/doc/modules/survival.rst
@@ -70,3 +70,6 @@ Example
 
 .. plot:: ../examples/plot_simulation_coxreg.py
     :include-source:
+
+.. plot:: ../examples/plot_conv_sccs_cv_results.py
+    :include-source:

--- a/examples/plot_conv_sccs_cv_results.py
+++ b/examples/plot_conv_sccs_cv_results.py
@@ -1,0 +1,150 @@
+"""
+====================================================================
+ConvSCCS cross validation on simulated longitudinal features example
+====================================================================
+
+In this example we simulate longitudinal data with preset relative incidence
+for each feature. We then perform a cross validation of the ConvSCCS model
+and compare the estimated coefficients to the relative incidences used for
+the simulation.
+"""
+from time import time
+import numpy as np
+from scipy.sparse import csr_matrix, hstack
+from matplotlib import cm
+import matplotlib.pylab as plt
+from tick.survival.simu_sccs import CustomEffects
+from tick.survival import SimuSCCS, ConvSCCS
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+# Simulation parameters
+seed = 0
+lags = 49
+n_samples = 2000
+n_intervals = 750
+n_corr = 3
+
+# Relative incidence functions used for the simulation
+ce = CustomEffects(lags + 1)
+null_effect = [ce.constant_effect(1)] * 2
+intermediate_effect = ce.bell_shaped_effect(2, 30, 15, 15)
+late_effects = ce.increasing_effect(2, curvature_type=4)
+
+sim_effects = [*null_effect, intermediate_effect, late_effects]
+
+n_features = len(sim_effects)
+n_lags = np.repeat(lags, n_features).astype('uint64')
+
+coeffs = np.log(np.hstack(sim_effects))
+
+# Time drift (age effect) used for the simulations.
+time_drift = lambda t: np.log(8 * np.sin(.01 * t) + 9)
+
+# Simaltion of the features.
+sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags,
+               time_drift=time_drift, coeffs=coeffs, seed=seed,
+               n_correlations=n_corr, verbose=False)
+features, censored_features, labels, censoring, coeffs = sim.simulate()
+
+# Plot the Hawkes kernel matrix used to generate the features.
+fig, ax = plt.subplots(figsize=(7, 6))
+heatmap = ax.pcolor(sim.hawkes_exp_kernels.adjacency, cmap=cm.Blues)
+divider = make_axes_locatable(ax)
+cax = divider.append_axes("right", size="5%", pad=0.5)
+fig.colorbar(heatmap, cax=cax)
+ax.set_title('Hawkes adjacency matrix used for the simulation');
+plt.show()
+
+## Add age_groups features to feature matrices.
+agegrps = [0, 125, 250, 375, 500, 625, 750]
+n_agegrps = len(agegrps) - 1
+
+feat_agegrp = np.zeros((n_intervals, n_agegrps))
+for i in range(n_agegrps):
+    feat_agegrp[agegrps[i]:agegrps[i + 1], i] = 1
+
+feat_agegrp = csr_matrix(feat_agegrp)
+features = [hstack([f, feat_agegrp]).tocsr() for f in features]
+censored_features = [hstack([f, feat_agegrp]).tocsr() for f in
+                     censored_features]
+n_lags = np.hstack([n_lags, np.zeros(n_agegrps)])
+
+# Learning
+# Example code for cross validation
+# start = time()
+# learner = ConvSCCS(n_lags=n_lags.astype('uint64'),
+#                    penalized_features=np.arange(n_features),
+#                    random_state=42)
+# strength_TV_range = (-4, -1)
+# strength_L1_range = (-5, -2)
+# _, cv_track = learner.fit_kfold_cv(features, labels, censoring,
+#                            strength_TV_range, strength_L1_range,
+#                            bootstrap=True, bootstrap_rep=50, n_cv_iter=50)
+# elapsed_time = time() - start
+# print("Elapsed time (model training): %.2f seconds \n" % elapsed_time)
+# print("Best model hyper parameters: \n", cv_track.best_model['strength'])
+# cv_track.plot_cv_report(35, 45)
+# plt.show()
+
+# using the parameters resulting from cross-validation
+learner = ConvSCCS(n_lags=n_lags.astype('uint64'),
+                   penalized_features=np.arange(n_features),
+                   random_state=42, strength_tv=0.0036999724314638062,
+                   strength_group_l1=0.0001917004158917066)
+
+_, bootstrap_ci = learner.fit(features, labels, censoring,
+                              bootstrap=True, bootstrap_rep=20)
+
+# Plot estimated parameters
+# when using cross validation output:
+# bootstrap_ci = cv_track.best_model['bootstrap_ci']
+# get bootstrap confidence intervals
+refitted_coeffs = bootstrap_ci['refit_coeffs']
+lower_bound = bootstrap_ci['lower_bound']
+upper_bound = bootstrap_ci['upper_bound']
+
+n_plots = np.sum([1 for l in n_lags if l > 0])
+n_rows = int(np.ceil(n_plots / 2))
+fig, axarr = plt.subplots(n_rows, 2, sharex=True, sharey=True, figsize=(10, 6))
+offset = 0
+c = 0
+for l in n_lags:
+    if l == 0:
+        offset += 1
+        continue
+    end = int(offset + l + 1)
+    m = refitted_coeffs[offset:end]
+    lb = lower_bound[offset:end]
+    ub = upper_bound[offset:end]
+    ax = axarr[c // 2][c % 2]
+    ax.plot(np.exp(coeffs[offset:end]), label="True RI")
+    ax.step(np.arange(l+1), np.exp(m), label="Estimated RI")
+    ax.fill_between(np.arange(l + 1), np.exp(lb), np.exp(ub), alpha=.5,
+                    color='orange', step='pre', label="95% boostrap CI")
+    offset = end
+    c += 1
+
+plt.suptitle('Estimated relative risks with 95% confidence bands')
+axarr[0][1].legend(loc='upper right')
+axarr[0][0].set_ylabel('Relative incidence')
+axarr[1][0].set_ylabel('Relative incidence')
+axarr[-1][0].set_xlabel('Time after exposure start')
+axarr[-1][1].set_xlabel('Time after exposure start')
+plt.show()
+
+normalize = lambda x: x / np.sum(x)
+offset = n_features * (lags + 1)
+m = np.repeat(refitted_coeffs[offset:], 125)
+lb = np.repeat(lower_bound[offset:], 125)
+ub = np.repeat(upper_bound[offset:], 125)
+plt.figure()
+plt.plot(np.arange(n_intervals),
+         normalize(np.exp(time_drift(np.arange(n_intervals)))))
+plt.step(np.arange(n_intervals), normalize(np.exp(m)))
+plt.fill_between(np.arange(n_intervals), np.exp(lb) / np.exp(m).sum(),
+                 np.exp(ub) / np.exp(m).sum(), alpha=.5, color='orange',
+                 step='pre')
+plt.xlabel('Age')
+plt.ylabel('Normalized Age Relative Incidence')
+plt.title("Normalized age effect with 95% confidence bands");
+plt.show()

--- a/lib/cpp/preprocessing/longitudinal_features_lagger.cpp
+++ b/lib/cpp/preprocessing/longitudinal_features_lagger.cpp
@@ -7,15 +7,8 @@
 #include "tick/preprocessing/longitudinal_features_lagger.h"
 
 LongitudinalFeaturesLagger::LongitudinalFeaturesLagger(
-<<<<<<< ours
-    const SBaseArrayDouble2dPtrList1D &features, const ulong n_lags)
-||||||| ancestor
-    const SBaseArrayDouble2dPtrList1D &features,
-    const ulong n_lags)
-=======
     const SBaseArrayDouble2dPtrList1D &features,
     const SArrayULongPtr n_lags)
->>>>>>> theirs
     : n_intervals(features[0]->n_rows()),
       n_lags(n_lags),
       n_samples(features.size()),
@@ -58,16 +51,7 @@ void LongitudinalFeaturesLagger::dense_lag_preprocessor(ArrayDouble2d &features,
       value = features(row, feature);
       max_col = col + n_cols_feature;
       if (value != 0) {
-<<<<<<< ours
-        while (row < censoring && row / n_intervals == sample &&
-               col / (n_lags + 1) == feature) {
-||||||| ancestor
-        while (row < censoring &&
-            row / n_intervals == sample &&
-            col / (n_lags + 1) == feature) {
-=======
         while (row < censoring && col < max_col) {
->>>>>>> theirs
           out[row * n_lagged_features + col] = value;
           row++;
           col++;
@@ -77,38 +61,6 @@ void LongitudinalFeaturesLagger::dense_lag_preprocessor(ArrayDouble2d &features,
   }
 }
 
-<<<<<<< ours
-void LongitudinalFeaturesLagger::sparse_lag_preprocessor(
-    ArrayULong &row, ArrayULong &col, ArrayDouble &data, ArrayULong &out_row,
-    ArrayULong &out_col, ArrayDouble &out_data, ulong censoring) const {
-  ulong j = 0;
-  for (ulong i = 0; i < row.size(); i++) {
-    double value = data[i];
-    ulong r = row[i];
-    ulong c = col[i] * (n_lags + 1);
-    ulong sample = r / n_intervals;
-    ulong feature = c / (n_lags + 1);
-    while (r < censoring && r / n_intervals == sample &&
-           c / (n_lags + 1) == feature) {
-||||||| ancestor
-void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
-                                                         ArrayULong &col,
-                                                         ArrayDouble &data,
-                                                         ArrayULong &out_row,
-                                                         ArrayULong &out_col,
-                                                         ArrayDouble &out_data,
-                                                         ulong censoring) const {
-  ulong j = 0;
-  for (ulong i = 0; i < row.size(); i++) {
-    double value = data[i];
-    ulong r = row[i];
-    ulong c = col[i] * (n_lags + 1);
-    ulong sample = r / n_intervals;
-    ulong feature = c / (n_lags + 1);
-    while (r < censoring &&
-        r / n_intervals == sample &&
-        c / (n_lags + 1) == feature) {
-=======
 void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
                                                          ArrayULong &col,
                                                          ArrayDouble &data,
@@ -128,7 +80,6 @@ void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
     new_col = offset;
 
     while (r < censoring && new_col < max_col) {
->>>>>>> theirs
       out_row[j] = r;
       out_col[j] = new_col;
       out_data[j] = value;

--- a/lib/cpp/preprocessing/longitudinal_features_lagger.cpp
+++ b/lib/cpp/preprocessing/longitudinal_features_lagger.cpp
@@ -7,15 +7,34 @@
 #include "tick/preprocessing/longitudinal_features_lagger.h"
 
 LongitudinalFeaturesLagger::LongitudinalFeaturesLagger(
+<<<<<<< ours
     const SBaseArrayDouble2dPtrList1D &features, const ulong n_lags)
+||||||| ancestor
+    const SBaseArrayDouble2dPtrList1D &features,
+    const ulong n_lags)
+=======
+    const SBaseArrayDouble2dPtrList1D &features,
+    const SArrayULongPtr n_lags)
+>>>>>>> theirs
     : n_intervals(features[0]->n_rows()),
       n_lags(n_lags),
       n_samples(features.size()),
       n_observations(n_samples * n_intervals),
       n_features(features[0]->n_cols()),
-      n_lagged_features(n_features * (n_lags + 1)) {
-  if (n_lags >= n_intervals) {
-    TICK_ERROR("n_lags must be between 0 and (n_intervals - 1)");
+      n_lagged_features(n_lags->sum() + n_lags->size()) {
+  col_offset = ArrayULong(n_lags->size());
+  col_offset.init_to_zero();
+  if (n_features != n_lags->size()) {
+    TICK_ERROR("Features matrix column number should match n_lags length.");
+  }
+  if ((*n_lags)[0] >= n_intervals) {
+    TICK_ERROR("n_lags elements must be between 0 and (n_intervals - 1).");
+  }
+  for (ulong i(1); i < n_lags->size(); i++) {
+    if ((*n_lags)[i] >= n_intervals) {
+      TICK_ERROR("n_lags elements must be between 0 and (n_intervals - 1).");
+    }
+    col_offset[i] = col_offset[i - 1] + (*n_lags)[i-1] + 1;
   }
 }
 
@@ -24,22 +43,31 @@ void LongitudinalFeaturesLagger::dense_lag_preprocessor(ArrayDouble2d &features,
                                                         ulong censoring) const {
   if (out.n_cols() != n_lagged_features) {
     TICK_ERROR(
-        "n_columns of &out is inconsistent with n_features * (n_lags + 1).");
+        "n_columns of &out should be equal to n_features + sum(n_lags).");
   }
   if (out.n_rows() != n_intervals) {
     TICK_ERROR("n_rows of &out is inconsistent with n_intervals");
   }
-  ulong sample, row, col;
+  ulong n_cols_feature, row, col, max_col;
   double value;
   for (ulong feature = 0; feature < n_features; feature++) {
+    n_cols_feature = (*n_lags)[feature] + 1;
     for (ulong j = 0; j < n_intervals; j++) {
       row = j;
-      sample = row / n_intervals;
-      col = feature * (n_lags + 1);
+      col = col_offset[feature];
       value = features(row, feature);
+      max_col = col + n_cols_feature;
       if (value != 0) {
+<<<<<<< ours
         while (row < censoring && row / n_intervals == sample &&
                col / (n_lags + 1) == feature) {
+||||||| ancestor
+        while (row < censoring &&
+            row / n_intervals == sample &&
+            col / (n_lags + 1) == feature) {
+=======
+        while (row < censoring && col < max_col) {
+>>>>>>> theirs
           out[row * n_lagged_features + col] = value;
           row++;
           col++;
@@ -49,6 +77,7 @@ void LongitudinalFeaturesLagger::dense_lag_preprocessor(ArrayDouble2d &features,
   }
 }
 
+<<<<<<< ours
 void LongitudinalFeaturesLagger::sparse_lag_preprocessor(
     ArrayULong &row, ArrayULong &col, ArrayDouble &data, ArrayULong &out_row,
     ArrayULong &out_col, ArrayDouble &out_data, ulong censoring) const {
@@ -61,11 +90,50 @@ void LongitudinalFeaturesLagger::sparse_lag_preprocessor(
     ulong feature = c / (n_lags + 1);
     while (r < censoring && r / n_intervals == sample &&
            c / (n_lags + 1) == feature) {
+||||||| ancestor
+void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
+                                                         ArrayULong &col,
+                                                         ArrayDouble &data,
+                                                         ArrayULong &out_row,
+                                                         ArrayULong &out_col,
+                                                         ArrayDouble &out_data,
+                                                         ulong censoring) const {
+  ulong j = 0;
+  for (ulong i = 0; i < row.size(); i++) {
+    double value = data[i];
+    ulong r = row[i];
+    ulong c = col[i] * (n_lags + 1);
+    ulong sample = r / n_intervals;
+    ulong feature = c / (n_lags + 1);
+    while (r < censoring &&
+        r / n_intervals == sample &&
+        c / (n_lags + 1) == feature) {
+=======
+void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
+                                                         ArrayULong &col,
+                                                         ArrayDouble &data,
+                                                         ArrayULong &out_row,
+                                                         ArrayULong &out_col,
+                                                         ArrayDouble &out_data,
+                                                         ulong censoring) const {
+  ulong j(0), r, c, offset, new_col, max_col;
+  double value;
+
+  for (ulong i = 0; i < data.size(); i++) {
+    value = data[i];
+    r = row[i];
+    c = col[i];
+    offset = col_offset[c];
+    max_col = offset + (*n_lags)[c] + 1;
+    new_col = offset;
+
+    while (r < censoring && new_col < max_col) {
+>>>>>>> theirs
       out_row[j] = r;
-      out_col[j] = c;
+      out_col[j] = new_col;
       out_data[j] = value;
       r++;
-      c++;
+      new_col++;
       j++;
     }
   }

--- a/lib/include/tick/preprocessing/longitudinal_features_lagger.h
+++ b/lib/include/tick/preprocessing/longitudinal_features_lagger.h
@@ -14,7 +14,8 @@
 class LongitudinalFeaturesLagger {
  protected:
   ulong n_intervals;
-  ulong n_lags;
+  SArrayULongPtr n_lags;
+  ArrayULong col_offset;
   ulong n_samples;
   ulong n_observations;
   ulong n_features;
@@ -22,7 +23,7 @@ class LongitudinalFeaturesLagger {
 
  public:
   LongitudinalFeaturesLagger(const SBaseArrayDouble2dPtrList1D &features,
-                             const ulong n_lags);
+                             const SArrayULongPtr n_lags);
 
   void dense_lag_preprocessor(ArrayDouble2d &features, ArrayDouble2d &out,
                               ulong censoring) const;
@@ -36,6 +37,7 @@ class LongitudinalFeaturesLagger {
   void serialize(Archive &ar) {
     ar(CEREAL_NVP(n_intervals));
     ar(CEREAL_NVP(n_lags));
+    ar(CEREAL_NVP(col_offset));
     ar(CEREAL_NVP(n_samples));
     ar(CEREAL_NVP(n_observations));
     ar(CEREAL_NVP(n_features));

--- a/lib/include/tick/survival/model_sccs.h
+++ b/lib/include/tick/survival/model_sccs.h
@@ -10,13 +10,21 @@
 #include "tick/base/base.h"
 #include "tick/base_model/model_lipschitz.h"
 
+<<<<<<< ours
 class DLL_PUBLIC ModelSCCS : public ModelLipschitz {
  public:
   using ModelLipschitz::get_class_name;
 
+||||||| ancestor
+class DLL_PUBLIC ModelSCCS : public ModelLipschitz  {
+=======
+
+class DLL_PUBLIC ModelSCCS : public ModelLipschitz  {
+>>>>>>> theirs
  protected:
   ulong n_intervals;
-  ulong n_lags;
+  SArrayULongPtr n_lags;
+  ArrayULong col_offset;
   ulong n_samples;
   ulong n_observations;
   ulong n_lagged_features;
@@ -33,8 +41,26 @@ class DLL_PUBLIC ModelSCCS : public ModelLipschitz {
 
  public:
   ModelSCCS(const SBaseArrayDouble2dPtrList1D &features,
+<<<<<<< ours
             const SArrayIntPtrList1D &labels,
             const SBaseArrayULongPtr censoring, ulong n_lags);
+||||||| ancestor
+                          const SArrayIntPtrList1D &labels,
+                          const SBaseArrayULongPtr censoring,
+                          ulong n_lags);
+
+  const char *get_class_name() const override {
+    return "LongitudinalMultinomial";
+  };
+=======
+            const SArrayIntPtrList1D &labels,
+            const SBaseArrayULongPtr censoring,
+            const SArrayULongPtr n_lags);
+
+  const char *get_class_name() const override {
+    return "LongitudinalMultinomial";
+  };
+>>>>>>> theirs
 
   double loss(const ArrayDouble &coeffs) override;
 

--- a/lib/include/tick/survival/model_sccs.h
+++ b/lib/include/tick/survival/model_sccs.h
@@ -10,17 +10,10 @@
 #include "tick/base/base.h"
 #include "tick/base_model/model_lipschitz.h"
 
-<<<<<<< ours
 class DLL_PUBLIC ModelSCCS : public ModelLipschitz {
  public:
   using ModelLipschitz::get_class_name;
 
-||||||| ancestor
-class DLL_PUBLIC ModelSCCS : public ModelLipschitz  {
-=======
-
-class DLL_PUBLIC ModelSCCS : public ModelLipschitz  {
->>>>>>> theirs
  protected:
   ulong n_intervals;
   SArrayULongPtr n_lags;
@@ -41,26 +34,9 @@ class DLL_PUBLIC ModelSCCS : public ModelLipschitz  {
 
  public:
   ModelSCCS(const SBaseArrayDouble2dPtrList1D &features,
-<<<<<<< ours
-            const SArrayIntPtrList1D &labels,
-            const SBaseArrayULongPtr censoring, ulong n_lags);
-||||||| ancestor
-                          const SArrayIntPtrList1D &labels,
-                          const SBaseArrayULongPtr censoring,
-                          ulong n_lags);
-
-  const char *get_class_name() const override {
-    return "LongitudinalMultinomial";
-  };
-=======
             const SArrayIntPtrList1D &labels,
             const SBaseArrayULongPtr censoring,
             const SArrayULongPtr n_lags);
-
-  const char *get_class_name() const override {
-    return "LongitudinalMultinomial";
-  };
->>>>>>> theirs
 
   double loss(const ArrayDouble &coeffs) override;
 

--- a/lib/swig/preprocessing/longitudinal_features_lagger.i
+++ b/lib/swig/preprocessing/longitudinal_features_lagger.i
@@ -8,7 +8,7 @@ class LongitudinalFeaturesLagger {
 
  public:
   LongitudinalFeaturesLagger(const SBaseArrayDouble2dPtrList1D &features,
-                             const ulong n_lags);
+                             const SArrayULongPtr n_lags);
 
   void dense_lag_preprocessor(ArrayDouble2d &features,
                               ArrayDouble2d &out,

--- a/lib/swig/survival/model_sccs.i
+++ b/lib/swig/survival/model_sccs.i
@@ -13,7 +13,7 @@ class ModelSCCS : public ModelLipschitz {
   ModelSCCS(const SBaseArrayDouble2dPtrList1D &features,
             const SArrayIntPtrList1D &labels,
             const SBaseArrayULongPtr censoring,
-            ulong n_lags);
+            const SArrayULongPtr n_lags);
 
   double loss(ArrayDouble &coeffs);
 

--- a/tick/hawkes/simulation/simu_hawkes_multi.py
+++ b/tick/hawkes/simulation/simu_hawkes_multi.py
@@ -167,5 +167,5 @@ class SimuHawkesMulti(Simu):
         """ Launches a series of n_simulations Hawkes simulation in a thread
         pool
         """
-        p = Pool(self.n_threads)
-        self._simulations = p.map(simulate_single, self._simulations)
+        with Pool(self.n_threads) as p:
+            self._simulations = p.map(simulate_single, self._simulations)

--- a/tick/preprocessing/__init__.py
+++ b/tick/preprocessing/__init__.py
@@ -3,10 +3,12 @@
 from .features_binarizer import FeaturesBinarizer
 from .longitudinal_features_product import LongitudinalFeaturesProduct
 from .longitudinal_features_lagger import LongitudinalFeaturesLagger
+from .longitudinal_samples_filter import LongitudinalSamplesFilter
 from .utils import safe_array, check_censoring_consistency,\
     check_longitudinal_features_consistency
 
 __all__ = ["FeaturesBinarizer", "LongitudinalFeaturesProduct",
-           "LongitudinalFeaturesLaggers", "safe_array",
+           "LongitudinalFeaturesLagger", "LongitudinalSamplesFilter",
+           "safe_array",
            "check_censoring_consistency",
            "check_longitudinal_features_consistency"]

--- a/tick/preprocessing/base/__init__.py
+++ b/tick/preprocessing/base/__init__.py
@@ -1,0 +1,3 @@
+# License: BSD 3 clause
+
+from .longitudinal_preprocessor import LongitudinalPreprocessor

--- a/tick/preprocessing/base/longitudinal_preprocessor.py
+++ b/tick/preprocessing/base/longitudinal_preprocessor.py
@@ -1,0 +1,31 @@
+# License: BSD 3 clause
+
+from abc import ABC, abstractmethod
+from tick.base import Base
+
+
+class LongitudinalPreprocessor(ABC, Base):
+    """An abstract base class for a longitudinal data preprocessors
+
+    Parameters
+    ----------
+    n_jobs : `int`, default=-1
+        Number of tasks to run in parallel. If set to -1, the number of tasks is
+        set to the number of cores.
+    """
+
+    def __init__(self, n_jobs=-1):
+        Base.__init__(self)
+        self.n_jobs = n_jobs
+
+    @abstractmethod
+    def fit(self, features, labels, censoring) -> None:
+        pass
+
+    @abstractmethod
+    def transform(self, features, labels, censoring) -> tuple:
+        pass
+
+    def fit_transform(self, features, labels=None, censoring=None) -> tuple:
+        self.fit(features, labels, censoring)
+        return self.transform(features, labels, censoring)

--- a/tick/preprocessing/longitudinal_features_lagger.py
+++ b/tick/preprocessing/longitudinal_features_lagger.py
@@ -2,21 +2,22 @@
 
 import numpy as np
 import scipy.sparse as sps
-from tick.base import Base
+from tick.preprocessing.base import LongitudinalPreprocessor
 from .build.preprocessing import LongitudinalFeaturesLagger\
     as _LongitudinalFeaturesLagger
 from .utils import check_longitudinal_features_consistency,\
     check_censoring_consistency
 
-class LongitudinalFeaturesLagger(Base):
+
+class LongitudinalFeaturesLagger(LongitudinalPreprocessor):
     """Transforms longitudinal exposure features to add columns representing
     lagged features.
 
-    This preprocessor transform an input list of `n_samples` numpy ndarrays or
+    This preprocessor transform an input list of `n_cases` numpy ndarrays or
     scipy.sparse.csr_matrices of shape `(n_intervals, n_features)` so as to
     add columns representing the lagged exposures. It outputs a list of
-    `n_samples` numpy arrays or  csr_matrices of shape
-    `(n_intervals, n_features * (n_lags + 1))`.
+    `n_cases` numpy arrays or  csr_matrices of shape
+    `(n_intervals, n_features + sum(n_lags + 1))`.
 
     Exposure can take two forms:
     - short repeated exposures: in that case, each column of the numpy arrays
@@ -28,15 +29,10 @@ class LongitudinalFeaturesLagger(Base):
 
     Parameters
     ----------
-    n_lags : `int`, default=0
+    n_lags : `numpy.ndarray`, shape=(n_features,), dtype="uint64"
         Number of lags to compute: the preprocessor adds columns representing
-        lag = 1, ..., n_lags. If lag = 0, this preprocessor does nothing.
-        n_lags must be non-negative.
-
-    Attributes
-    ----------
-    mapper : `dict`
-        Map lagged features to column indexes of the resulting matrices.
+        lag = 1, ..., n_lags[i] for each feature [i]. If `n_lags` is a null
+        vector, this preprocessor does nothing. `n_lags` must be non-negative.
 
     Examples
     --------
@@ -51,23 +47,23 @@ class LongitudinalFeaturesLagger(Base):
     ...                         [0, 0, 0]], dtype="float64")
     ...             ]
     >>> censoring = np.array([3, 2], dtype="uint64")
-    >>> lfl = LongitudinalFeaturesLagger(n_lags=2)
+    >>> n_lags = np.array([2, 1, 0], dtype='uint64')
+    >>> lfl = LongitudinalFeaturesLagger(n_lags)
     >>> product_features = lfl.fit_transform(features)
     >>> # output comes as a list of sparse matrices or 2D numpy arrays
     >>> product_features.__class__
     <class 'list'>
     >>> [x.toarray() for x in product_features]
-    [array([[ 0.,  0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.],
-           [ 0.,  0.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
-           [ 0.,  0.,  0.,  0.,  0.,  1.,  1.,  0.,  0.]]), array([[ 1.,  0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.],
-           [ 0.,  1.,  0.,  0.,  1.,  0.,  1.,  0.,  0.],
-           [ 0.,  0.,  1.,  0.,  0.,  1.,  0.,  1.,  0.]])]
-
+    [array([[ 0.,  0.,  0.,  1.,  0.,  0.],
+            [ 0.,  0.,  0.,  0.,  1.,  0.],
+            [ 0.,  0.,  0.,  0.,  0.,  1.]]),
+     array([[ 1.,  0.,  0.,  1.,  0.,  0.],
+            [ 0.,  1.,  0.,  0.,  1.,  1.],
+            [ 0.,  0.,  0.,  0.,  0.,  0.]])]
     """
 
     _attrinfos = {
         "n_lags": {"writable": False},
-        "_mapper": {"writable": False},
         "_n_init_features": {"writable": False},
         "_n_output_features": {"writable": False},
         "_n_intervals": {"writable": False},
@@ -75,48 +71,36 @@ class LongitudinalFeaturesLagger(Base):
         "_fitted": {"writable": False}
     }
 
-    def __init__(self, n_lags=0, n_jobs=-1):
-        Base.__init__(self)
-        if n_lags < 0:
-            raise ValueError("`n_lags` should be non-negative.")
+    def __init__(self, n_lags, n_jobs=-1):
+        LongitudinalPreprocessor.__init__(self, n_jobs=n_jobs)
+        if not isinstance(n_lags, np.ndarray) or n_lags.dtype != 'uint64':
+            raise ValueError('`n_lags` should be a numpy array of dtype uint64')
         self.n_lags = n_lags
-        self.n_jobs = n_jobs
+        self._n_init_features = None
+        self._n_output_features = None
+        self._n_intervals = None
         self._cpp_preprocessor = None
-        self._reset()
+        self._fitted = False
 
     def _reset(self):
         """Resets the object its initial construction state."""
         self._set("_n_init_features", None)
         self._set("_n_output_features", None)
         self._set("_n_intervals", None)
-        self._set("_mapper", {})
         self._set("_cpp_preprocessor", None)
         self._set("_fitted", False)
 
-    @property
-    def mapper(self):
-        """Get the mapping between the feature lags and column indexes.
-
-        Returns
-        -------
-        output : `dict`
-            The column index - feature mapping.
-        """
-        if not self._fitted:
-            raise ValueError("Cannot get mapper if object has not been fitted.")
-        return self._mapper.copy()
-
-    def fit(self, X, censoring=None):
+    def fit(self, features, labels=None, censoring=None):
         """Fit the feature lagger using the features matrices list.
 
         Parameters
         ----------
-        X : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
-            list of length n_samples, each element of the list of
+        features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
+            list of length n_cases, each element of the list of
             shape=(n_intervals, n_features)
             The list of features matrices.
 
-        censoring : `numpy.ndarray`, shape=(n_samples,), dtype="uint64"
+        censoring : `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
             The censoring data. This array should contain integers in
             [1, n_intervals]. If the value i is equal to n_intervals, then there
             is no censoring for sample i. If censoring = c < n_intervals, then
@@ -130,33 +114,33 @@ class LongitudinalFeaturesLagger(Base):
             The fitted current instance.
         """
         self._reset()
-        base_shape = X[0].shape
-        X = check_longitudinal_features_consistency(X, base_shape, "float64")
+        base_shape = features[0].shape
+        if base_shape[1] != len(self.n_lags):
+            raise ValueError('Number of columns from feature matrices differs'
+                             'from self.n_lags length.')
+        features = check_longitudinal_features_consistency(features, base_shape,
+                                                           "float64")
         n_intervals, n_init_features = base_shape
         self._set("_n_init_features", n_init_features)
         self._set("_n_intervals", n_intervals)
-        mapper = {i: tuple(i + j for j in range(self.n_lags + 1))
-                  for i in range(self._n_init_features)}
-        self._set("_mapper", mapper)
-        self._set("_n_output_features", int(n_init_features *
-                                            (self.n_lags + 1)))
+        self._set("_n_output_features", int((self.n_lags + 1).sum()))
         self._set("_cpp_preprocessor",
-                  _LongitudinalFeaturesLagger(X, self.n_lags))
+                  _LongitudinalFeaturesLagger(features, self.n_lags))
         self._set("_fitted", True)
 
         return self
 
-    def transform(self, X, censoring=None):
+    def transform(self, features, labels=None, censoring=None):
         """Add lagged features to the given features matrices list.
 
         Parameters
         ----------
-        X : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
-            list of length n_samples, each element of the list of
+        features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
+            list of length n_cases, each element of the list of
             shape=(n_intervals, n_features)
             The list of features matrices.
 
-        censoring : `numpy.ndarray`, shape=(n_samples,), dtype='uint64', default='None'
+        censoring : `numpy.ndarray`, shape=(n_cases,), dtype='uint64', default='None'
             The censoring data. This array should contain integers in
             [1, n_intervals]. If the value i is equal to n_intervals, then there
             is no censoring for sample i. If censoring = c < n_intervals, then
@@ -170,51 +154,23 @@ class LongitudinalFeaturesLagger(Base):
             The list of features matrices with added lagged features.
         """
 
-        n_samples = len(X)
+        n_samples = len(features)
         if censoring is None:
             censoring = np.full((n_samples,), self._n_intervals,
                                 dtype="uint64")
         censoring = check_censoring_consistency(censoring, n_samples)
         base_shape = (self._n_intervals, self._n_init_features)
-        X = check_longitudinal_features_consistency(X, base_shape, "float64")
-        if sps.issparse(X[0]):
+        features = check_longitudinal_features_consistency(features, base_shape,
+                                                           "float64")
+        if sps.issparse(features[0]):
             X_with_lags = [self._sparse_lagger(x, int(censoring[i]))
-                           for i, x in enumerate(X)]
-            # Don't get why int() is required here as censoring_i is uint64
+                           for i, x in enumerate(features)]
+            # TODO: Don't get why int() is required here as censoring_i is uint64
         else:
             X_with_lags = [self._dense_lagger(x, int(censoring[i]))
-                           for i, x in enumerate(X)]
+                           for i, x in enumerate(features)]
 
-        return X_with_lags
-
-    def fit_transform(self, X, censoring=None):
-        """Fit and add the lagged features computated using the features
-        matrices list.
-
-        Parameters
-        ----------
-        X : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
-            list of length n_samples, each element of the list of
-            shape=(n_intervals, n_features)
-            The list of features matrices.
-
-        censoring : `numpy.ndarray`, shape=(n_samples,), dtype='uint64', default='None'
-            The censoring data. This array should contain integers in
-            [1, n_intervals]. If the value i is equal to n_intervals, then there
-            is no censoring for sample i. If censoring = c < n_intervals, then
-            the observation of sample i is stopped at interval c, that is, the
-            row c - 1 of the correponding matrix. The last n_intervals - c rows
-            are then set to 0.
-
-        Returns
-        -------
-        output : `[numpy.ndarrays]`  or `[csr_matrices]`, shape=(n_intervals, n_features)
-            The list of features matrices with added lagged features.
-        """
-        self.fit(X, censoring)
-        X_with_lags = self.transform(X, censoring)
-
-        return X_with_lags
+        return X_with_lags, labels, censoring
 
     def _dense_lagger(self, feature_matrix, censoring_i):
         output = np.zeros((self._n_intervals, self._n_output_features),
@@ -227,7 +183,7 @@ class LongitudinalFeaturesLagger(Base):
 
     def _sparse_lagger(self, feature_matrix, censoring_i):
         coo = feature_matrix.tocoo()
-        estimated_nnz = coo.nnz * (self.n_lags + 1)
+        estimated_nnz = coo.nnz * int((self.n_lags + 1).sum())
         out_row = np.zeros((estimated_nnz,), dtype="uint64")
         out_col = np.zeros((estimated_nnz,), dtype="uint64")
         out_data = np.zeros((estimated_nnz,), dtype="float64")

--- a/tick/preprocessing/longitudinal_samples_filter.py
+++ b/tick/preprocessing/longitudinal_samples_filter.py
@@ -1,0 +1,83 @@
+import numpy as np
+from operator import itemgetter
+from tick.preprocessing.base import LongitudinalPreprocessor
+
+
+class LongitudinalSamplesFilter(LongitudinalPreprocessor):
+    """Longitudinal data preprocessor which filters out samples for which all
+    labels are null over the entire observation period.
+
+    Parameters
+    ----------
+    n_jobs : `int`, default=-1
+        Number of tasks to run in parallel. If set to -1, the number of tasks is
+        set to the number of cores.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse import csr_matrix
+    >>> from tick.preprocessing import LongitudinalSamplesFilter
+    >>> features = [csr_matrix([[0, 1, 0],
+    ...                         [0, 0, 0],
+    ...                         [0, 0, 1]], dtype="float64"),
+    ...             csr_matrix([[1, 1, 0],
+    ...                         [0, 0, 1],
+    ...                         [0, 0, 0]], dtype="float64")
+    ...             ]
+    >>> censoring = np.array([3, 2], dtype="uint64")
+    >>> labels = [np.array([0, 1, 0], dtype="uint64"), np.zeros(3, dtype="uint64")]
+    >>> n_lags = np.array([2, 1, 0], dtype='uint64')
+    >>> lfl = LongitudinalSamplesFilter()
+    >>> features, labels, censoring = lfl.fit_transform(features, labels, censoring)
+    >>> # output comes as a list of sparse matrices or 2D numpy arrays
+    >>> features.__class__
+    <class 'list'>
+    >>> [x.toarray() for x in features]
+    [array([[ 0.,  1.,  0.],
+            [ 0.,  0.,  0.],
+            [ 0.,  0.,  1.]])]
+    >>> labels
+    [array([ 0,  1,  0])]
+    >>> censoring
+    array([ 3])
+    """
+
+    _attrinfos = {
+        "_mask": {"writable": False},
+        "_n_active_patients": {"writable": False},
+        "_n_patients": {"writable": False},
+    }
+
+    def __init__(self, n_jobs=-1):
+        LongitudinalPreprocessor.__init__(self, n_jobs=n_jobs)
+        self._mask = None
+        self._n_active_patients = None
+        self._n_patients = None
+
+    def fit(self, features, labels, censoring):
+        nnz = [len(np.nonzero(arr)[0]) > 0 for arr in labels]
+        self._set('_mask', [idx for idx, feat in enumerate(features)
+                            if feat.sum() > 0 and nnz[idx]])
+        self._set('_n_active_patients', len(self._mask))
+        self._set('_n_patients', len(features))
+
+        return self
+
+    def transform(self, features, labels, censoring):
+        if self._n_active_patients <= 1:
+            raise ValueError("There should be more than one positive sample per\
+                 batch with nonzero_features. Please check the input data.")
+        if self._n_active_patients < self._n_patients:
+            features_filter = itemgetter(*self._mask)
+            features = features_filter(features)
+            labels = features_filter(labels)
+            censoring = censoring[self._mask]
+
+        if self._n_active_patients == 1:
+            features = [features]
+            labels = [labels]
+            censoring = np.array(censoring, dtype='uint32')
+
+        return features, labels, censoring
+

--- a/tick/preprocessing/tests/longitudinal_features_lagger_test.py
+++ b/tick/preprocessing/tests/longitudinal_features_lagger_test.py
@@ -3,8 +3,7 @@
 import numpy as np
 from scipy.sparse import csr_matrix
 import unittest
-from tick.preprocessing.longitudinal_features_lagger\
-    import LongitudinalFeaturesLagger
+from tick.preprocessing import LongitudinalFeaturesLagger
 
 
 class Test(unittest.TestCase):
@@ -21,22 +20,24 @@ class Test(unittest.TestCase):
 
         self.censoring = np.array([2, 3], dtype="uint64")
 
-        self.expected_output = [np.array([[0, 0, 1, 0, 0, 0],
-                                          [0, 0, 0, 1, 0, 0],
-                                          [0, 0, 0, 0, 0, 0.]]),
-                                np.array([[1, 0, 1, 0, 1, 0],
-                                          [0, 1, 0, 1, 1, 1],
-                                          [1, 0, 1, 0, 0, 1.]])
+        self.expected_output = [np.array([[0, 0, 1, 0, 0, 0, 0],
+                                          [0, 0, 0, 1, 0, 0, 0],
+                                          [0, 0, 0, 0, 0, 0, 0.]]),
+                                np.array([[1, 0, 1, 0, 0, 1, 0],
+                                          [0, 1, 0, 1, 0, 1, 1],
+                                          [1, 0, 1, 0, 1, 0, 1.]])
                                 ]
 
+        self.n_lags = np.array([1, 2, 1], dtype="uint64")
+
     def test_dense_pre_convolution(self):
-        feat_prod = LongitudinalFeaturesLagger(n_lags=1)\
-            .fit_transform(self.features, self.censoring)
+        feat_prod, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags)\
+            .fit_transform(self.features, censoring=self.censoring)
         np.testing.assert_equal(feat_prod, self.expected_output)
 
     def test_sparse_pre_convolution(self):
-        feat_prod = LongitudinalFeaturesLagger(n_lags=1)\
-            .fit_transform(self.sparse_features, self.censoring)
+        feat_prod, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags)\
+            .fit_transform(self.sparse_features, censoring=self.censoring)
         feat_prod = [f.todense() for f in feat_prod]
         np.testing.assert_equal(feat_prod, self.expected_output)
 

--- a/tick/preprocessing/tests/longitudinal_features_product_test.py
+++ b/tick/preprocessing/tests/longitudinal_features_product_test.py
@@ -3,21 +3,21 @@
 import numpy as np
 from scipy.sparse import csr_matrix
 import unittest
-from tick.preprocessing.longitudinal_features_product import LongitudinalFeaturesProduct
+from tick.preprocessing import LongitudinalFeaturesProduct
 
 
 class Test(unittest.TestCase):
 
     def setUp(self):
-        self.short_exposures = [np.array([[0, 1, 0],
+        self.finite_exposures = [np.array([[0, 1, 0],
                                           [0, 0, 0],
                                           [0, 1, 1]], dtype="float64"),
                                 np.array([[1, 1, 1],
                                           [0, 0, 1],
                                           [1, 1, 0]], dtype="float64")
                                 ]
-        self.sparse_short_exposures = [csr_matrix(f)
-                                       for f in self.short_exposures]
+        self.sparse_finite_exposures = [csr_matrix(f)
+                                       for f in self.finite_exposures]
 
         self.infinite_exposures = [np.array([[0, 1, 0],
                                              [0, 0, 0],
@@ -29,8 +29,7 @@ class Test(unittest.TestCase):
         self.sparse_infinite_exposures = [csr_matrix(f)
                                           for f in self.infinite_exposures]
 
-
-    def test_short_features_product(self):
+    def test_finite_features_product(self):
         expected_output = \
             [np.array([[0, 1, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0, 0],
@@ -41,13 +40,12 @@ class Test(unittest.TestCase):
                        [1, 1, 0, 1, 0, 0],
                        ], dtype="float64")
              ]
-        pp = LongitudinalFeaturesProduct("short")
+        pp = LongitudinalFeaturesProduct("finite")
 
-        feat_prod = pp.fit_transform(self.short_exposures)
+        feat_prod, _, _ = pp.fit_transform(self.finite_exposures)
         np.testing.assert_equal(feat_prod, expected_output)
 
-        feat_prod = pp.fit_transform(self.sparse_short_exposures)
-        print(feat_prod.__class__)
+        feat_prod, _, _ = pp.fit_transform(self.sparse_finite_exposures)
         feat_prod = [f.toarray() for f in feat_prod]
         np.testing.assert_equal(feat_prod, expected_output)
 
@@ -63,7 +61,7 @@ class Test(unittest.TestCase):
                        ], dtype="float64")
              ]
         sparse_feat = [csr_matrix(f) for f in self.infinite_exposures]
-        feat_prod = LongitudinalFeaturesProduct("infinite")\
+        feat_prod, _, _ = LongitudinalFeaturesProduct("infinite")\
             .fit_transform(sparse_feat)
         feat_prod = [f.toarray() for f in feat_prod]
         np.testing.assert_equal(feat_prod, expected_output)

--- a/tick/preprocessing/tests/longitudinal_samples_filter_test.py
+++ b/tick/preprocessing/tests/longitudinal_samples_filter_test.py
@@ -1,0 +1,55 @@
+# License: BSD 3 clause
+
+import numpy as np
+from scipy.sparse import csr_matrix
+import unittest
+from tick.preprocessing import LongitudinalSamplesFilter
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        self.features = [np.array([[0, 1, 0],
+                                   [0, 0, 0],
+                                   [0, 1, 1]], dtype="float64"),
+                         np.array([[1, 1, 1],
+                                   [0, 0, 1],
+                                   [1, 1, 0]], dtype="float64"),
+                         np.zeros((3, 3), dtype="float64"),
+                         np.array([[1, 1, 1],
+                                   [0, 0, 1],
+                                   [1, 1, 0]], dtype="float64"),
+                         ]
+        self.sparse_features = [csr_matrix(f) for f in self.features]
+
+        self.labels = [np.array([0, 0, 1], dtype="float64"),
+                       np.array([1, 0, 0], dtype="float64"),
+                       np.array([0, 1, 0], dtype="float64"),
+                       np.zeros((3,), dtype="float64")
+                       ]
+
+        self.censoring = np.array([2, 3, 3, 1], dtype="uint64")
+
+        self.expected_output = (
+            self.features[0:2],
+            self.labels[0:2],
+            self.censoring[0:2]
+        )
+
+    def test_dense_fitlering(self):
+        output = LongitudinalSamplesFilter()\
+            .fit_transform(self.features, self.labels, self.censoring)
+        [np.testing.assert_equal(out, self.expected_output[i]) for
+         i, out in enumerate(output)]
+
+    def test_sparse_filtering(self):
+        output = LongitudinalSamplesFilter()\
+            .fit_transform(self.sparse_features, self.labels, self.censoring)
+        np.testing.assert_equal([out.todense() for out in output[0]],
+                                self.expected_output[0])
+        [np.testing.assert_equal(out, self.expected_output[i+1]) for
+         i, out in enumerate(output[1:])]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tick/random/tests/random_test.py
+++ b/tick/random/tests/random_test.py
@@ -232,8 +232,8 @@ class Test(unittest.TestCase):
 
         if parallelization_type == 'multiprocessing':
 
-            pool = Pool(processes=n_workers)
-            samples = pool.starmap(test_uniform_threaded, args)
+            with Pool(processes=n_workers) as pool:
+                samples = pool.starmap(test_uniform_threaded, args)
 
             samples = np.array(samples)
 

--- a/tick/survival/__init__.py
+++ b/tick/survival/__init__.py
@@ -11,10 +11,13 @@ from .model_sccs import ModelSCCS
 
 from .simu_coxreg import SimuCoxReg
 from .simu_sccs import SimuSCCS
+from .convolutional_sccs import ConvSCCS
 
 __all__ = [
     "ModelCoxRegPartialLik",
+    "SimuSCCS",
     "ModelSCCS",
+    "ConvSCCS",
     "kaplan_meier",
     "nelson_aalen"
 ]

--- a/tick/survival/convolutional_sccs.py
+++ b/tick/survival/convolutional_sccs.py
@@ -1,0 +1,922 @@
+import numpy as np
+from abc import ABC
+from operator import itemgetter
+from collections import namedtuple
+from sklearn.model_selection import StratifiedKFold
+from tick.base import Base
+from tick.prox import ProxZero, ProxMulti, ProxTV, ProxEquality, \
+    ProxGroupL1
+from tick.solver import SVRG
+from tick.survival import SimuSCCS, ModelSCCS
+from tick.preprocessing import LongitudinalSamplesFilter, \
+    LongitudinalFeaturesLagger
+from scipy.stats import uniform
+import matplotlib.pylab as plt
+from mpl_toolkits.mplot3d import Axes3D
+from matplotlib import cm
+from tick.preprocessing.utils import check_longitudinal_features_consistency, \
+    check_censoring_consistency
+
+# Case classes
+Bootstrap_CI = namedtuple('Bootstrap_CI', ['refit_coeffs', 'median',
+                                           'lower_bound', 'upper_bound',
+                                           'confidence'])
+
+Strengths = namedtuple('Strengths', ['strength_tv', 'strength_group_l1'])
+
+
+# TODO later: exploit new options of SVRG (parallel fit, variance_reduction...)
+class ConvSCCS(ABC, Base):
+    _const_attr = [
+        # constructed attributes
+        '_preprocessor_obj',
+        '_model_obj',
+        '_solver_obj',
+        # user defined parameters
+        '_n_lags',
+        '_penalized_features',
+        '_strength_tv',
+        '_strength_group_l1',
+        '_random_state',
+        # computed attributes
+        'n_cases',
+        'n_intervals',
+        'n_features',
+        'n_coeffs',
+        'coeffs',
+        '_features_offset',
+        '_fitted',
+        '_step_size',
+        # refit coeffs, median, and CI data
+        'bootstrap_coeffs',
+    ]
+
+    _attrinfos = {key: {'writable': False} for key in _const_attr}
+
+    def __init__(self, n_lags: np.array,
+                 penalized_features: np.array,
+                 strength_tv=None, strength_group_l1=None,
+                 step: float = None, tol: float = 1e-5, max_iter: int = 100,
+                 verbose: bool = False, print_every: int = 10,
+                 record_every: int = 10, random_state: int = None):
+        """ConvSCCS model. This class allows to estimate a lagged effect for
+        each feature. TV and Group L1 penalties might be used to penalize the
+        coefficient groups modelling the lagged effects.
+
+        Parameters
+        ----------
+        n_lags : `numpy.ndarray`, shape=(n_features,), dtype="uint64"
+            Number of lags per feature. The model will regress labels on the
+            last observed values of the features over their corresponding
+            `n_lags` time intervals. `n_lags` values must be between 0 and
+            `n_intervals` - 1.
+
+        penalized_features : `numpy.ndarray`, shape=(n_features,), dtype="bool"
+            Booleans indicating whether the features should be penalised or
+            not.
+
+        strength_tv : `float`, default=None
+            Strength of the TV penalization. This value should be `None` or
+            greater than 0.
+
+        strength_group_l1 : `float`, default=None
+            Strength of the group Lasso penalization. This value should be
+            `None` or greater than 0.
+
+        step : `float`
+            Step-size parameter, the most important parameter of the solver.
+            Whenever possible, this can be automatically tuned as
+            ``step = 1 / model.get_lip_max()``. Otherwise, use a
+            try-an-improve approach.
+
+        tol : `float`, default=1e-5
+            The tolerance of the solver (iterations stop when the stopping
+            criterion is below it).
+
+        max_iter : `int`, default=100
+            Maximum number of iterations of the solver, namely maximum
+            number of epochs.
+
+        verbose : `bool`, default=False
+            If `True`, solver verboses history, otherwise nothing is
+            displayed.
+
+        random_state : `int`, default=None
+            If not None, the seed of the random sampling.
+
+
+        Attributes
+        ----------
+        n_cases : `int` (read-only)
+            Number of samples
+
+        n_intervals : `int` (read-only)
+            Number of time intervals
+
+        n_features : `int` (read-only)
+            Number of features
+
+        n_coeffs : `int` (read-only)
+            Total number of coefficients of the model
+
+        coeffs : `numpy.ndarray`, shape=(n_coeffs,), dtype="float64" (read-only)
+            Coefficients of the model.
+
+        bootstrap_coeffs : `Bootstrap_CI` (read-only)
+            Bootstrap coefficients and confidence intervals of the model.
+        """
+        Base.__init__(self)
+        # Init objects to be computed later
+        self.n_cases = None
+        self.n_intervals = None
+        self.n_features = None
+        self.n_coeffs = None
+        self.coeffs = None
+        self.bootstrap_coeffs = Bootstrap_CI(list(), list(), list(), list(),
+                                             None)
+        self._fitted = None
+        self._step_size = None
+
+        # Init user defined parameters
+        self._features_offset = None
+        self._n_lags = None
+        self.n_lags = n_lags
+        self._penalized_features = None
+        self.penalized_features = penalized_features
+        self._strength_tv = None
+        self._strength_group_l1 = None
+        self.strength_tv = strength_tv
+        self.strength_group_l1 = strength_group_l1
+
+        self._step_size = step
+        self.tol = tol
+        self.max_iter = max_iter
+        self.verbose = verbose,
+        self.print_every = print_every
+        self.record_every = record_every
+        random_state = int(np.random.randint(0, 1000, 1)[0]
+                           if random_state is None else random_state)
+        self._random_state = None
+        self.random_state = random_state
+
+        # Construct objects
+        self._preprocessor_obj = self._construct_preprocessor_obj()
+        self._model_obj = None
+        self._solver_obj = self._construct_solver_obj(step, max_iter, tol,
+                                                      print_every, record_every,
+                                                      verbose, random_state)
+
+    # Interface
+    def fit(self, features: list, labels: list,
+            censoring: np.array, bootstrap: bool = False,
+            bootstrap_rep: int = 200,
+            bootstrap_confidence: float = .95):
+        """Fit the model according to the given training data.
+
+        Parameters
+        ----------
+        features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
+            list of length n_cases, each element of the list of
+            shape=(n_intervals, n_features)
+            The list of features matrices.
+
+        labels : `list` of `numpy.ndarray`,
+            list of length n_cases, each element of the list of
+            shape=(n_intervals,)
+            The labels vector
+
+        censoring : `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
+            The censoring data. This array should contain integers in
+            [1, n_intervals]. If the value i is equal to n_intervals, then there
+            is no censoring for sample i. If censoring = c < n_intervals, then
+            the observation of sample i is stopped at interval c, that is, the
+            row c - 1 of the corresponding matrix. The last n_intervals - c rows
+            are then set to 0.
+
+        bootstrap : `bool`, default=False
+            Activate parametric bootstrap confidence intervals computation.
+
+        bootstrap_rep : `int`, default=200
+            Number of parametric bootstrap iterations
+
+        bootstrap_confidence : `float`, default=.95
+            Confidence level of the bootstrapped confidence intervals
+
+        Returns
+        -------
+        output : `LearnerSCCS`
+            The current instance with given data
+        """
+        p_features, p_labels, p_censoring = self._prefit(features, labels,
+                                                         censoring)
+        self._fit(project=False)
+        self._postfit(p_features, p_labels, p_censoring, False,
+                      bootstrap, bootstrap_rep, bootstrap_confidence)
+
+        return self.coeffs, self.bootstrap_coeffs
+
+    def score(self, features=None, labels=None, censoring=None):
+        """Returns the negative log-likelihood of the model, using the current
+        fitted coefficients on the passed data.
+        If no data is passed, the negative log-likelihood is computed using the
+        data used for training.
+
+        Parameters
+        ----------
+        features : `None` or `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
+            list of length n_cases, each element of the list of
+            shape=(n_intervals, n_features)
+            The list of features matrices.
+
+        labels : `None` or `list` of `numpy.ndarray`,
+            list of length n_cases, each element of the list of
+            shape=(n_intervals,)
+            The labels vector
+
+        censoring : `None` or `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
+            The censoring data. This array should contain integers in
+            [1, n_intervals]. If the value i is equal to n_intervals, then there
+            is no censoring for sample i. If censoring = c < n_intervals, then
+            the observation of sample i is stopped at interval c, that is, the
+            row c - 1 of the corresponding matrix. The last n_intervals - c rows
+            are then set to 0.
+
+        Returns
+        -------
+        output : `float`
+            The value of the negative log-likelihood
+        """
+
+        return self._score(features, labels, censoring, preprocess=True)
+
+    def fit_kfold_cv(self, features, labels, censoring,
+                     strength_tv_range: tuple=(),
+                     strength_group_l1_range: tuple=(), logspace=True,
+                     n_cv_iter: int= 30, n_folds: int = 3, shuffle: bool = True,
+                     bootstrap: bool = False, bootstrap_rep: int = 100,
+                     bootstrap_confidence: float = .95):
+        """Perform a cross validation to find optimal hyperparameters given
+        training data. Cross validation using stratified K-folds and random
+        search, parameters being sampled uniformly in the range (logspace or
+        linspace) specified by the user.
+
+        Parameters
+        ----------
+        features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`
+            list of length n_cases, each element of the list of
+            shape=(n_intervals, n_features)
+            The list of features matrices.
+
+        labels : `list` of `numpy.ndarray`,
+            list of length n_cases, each element of the list of
+            shape=(n_intervals,)
+            The labels vector
+
+        censoring : `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
+            The censoring data. This array should contain integers in
+            [1, n_intervals]. If the value i is equal to n_intervals, then there
+            is no censoring for sample i. If censoring = c < n_intervals, then
+            the observation of sample i is stopped at interval c, that is, the
+            row c - 1 of the corresponding matrix. The last n_intervals - c rows
+            are then set to 0.
+
+        strength_tv_range : `tuple`, shape=(2,), dtype="int"
+            Range in which sampling TV penalization strength during the
+            random search. `logspace=True`, range values are understood as
+            powers of ten, i.e `(-5, -1)` will result in samples being in
+            `10**(-5), 10**(-1)`.
+
+        strength_group_l1_range : `tuple`, shape=(2,), dtype="int"
+            Range in which sampling group L1 penalization strength during the
+            random search. `logspace=True`, range values are understood as
+            powers of ten, i.e `(-5, -1)` will result in samples being in
+            `10**(-5), 10**(-1)`.
+
+        logspace : `bool`
+            If `True`, hyperparameters are samples in logspace.
+
+        n_cv_iter : `int`
+            Number of hyperparameters samples to draw when performing
+            random search.
+
+        n_folds : `int`
+            Number of folds used to perform the cross validation.
+
+        shuffle : `bool`
+            If `True`, the data is shuffled before performing train / validation
+            / test splits.
+
+        bootstrap : `bool`, default=False
+            Activate parametric bootstrap confidence intervals computation.
+
+        bootstrap_rep : `int`, default=200
+            Number of parametric bootstrap iterations
+
+        bootstrap_confidence : `float`, default=.95
+            Confidence level of the bootstrapped confidence intervals
+
+        Returns
+        -------
+        output : `LearnerSCCS`
+            The current instance with given data
+        """
+        # setup the model and preprocess the data
+        p_features, p_labels, p_censoring = self._prefit(features, labels,
+                                                         censoring)
+        # split the data with stratified KFold
+        kf = StratifiedKFold(n_folds, shuffle, self.random_state)
+        labels_interval = np.nonzero(p_labels)[1]
+
+        # Training loop
+        model_global_parameters = {
+            "n_intervals": self.n_intervals,
+            "n_lags": self.n_lags,
+            "n_features": self.n_features,
+        }
+        cv_tracker = CrossValidationTracker(model_global_parameters)
+        generators = self._construct_generator_obj(strength_tv_range,
+                                                   strength_group_l1_range,
+                                                   logspace)
+        # TODO later: parallelize CV
+        i = 0
+        while i < n_cv_iter:
+            self._set('coeffs', np.zeros(self.n_coeffs))
+            self._strengths = [g.rvs(1)[0] for g in generators]
+
+            train_scores = []
+            test_scores = []
+            for train_index, test_index in kf.split(p_features, labels_interval):
+                train = itemgetter(*train_index.tolist())
+                test = itemgetter(*test_index.tolist())
+                X_train, X_test = list(train(p_features)), list(test(p_features))
+                y_train, y_test = list(train(p_labels)), list(test(p_labels))
+                censoring_train, censoring_test = p_censoring[train_index], \
+                    p_censoring[test_index]
+
+                self._model_obj.fit(X_train, y_train, censoring_train)
+                self._fit(project=False)
+
+                train_scores.append(self._score())
+                test_scores.append(self._score(X_test, y_test, censoring_test))
+
+            cv_tracker.log_cv_iteration({'strength': self._strengths},
+                                        np.array(train_scores),
+                                        np.array(test_scores))
+            i += 1
+
+        best_parameters = cv_tracker.find_best_params()
+        best_strength = best_parameters["strength"]
+
+        # refit best model on all the data
+        self._set('coeffs', np.zeros(self.n_coeffs))
+        self._strengths = best_strength
+
+        self._model_obj.fit(p_features, p_labels, p_censoring)
+        coeffs, bootstrap_ci = self._postfit(p_features, p_labels, p_censoring,
+                                             True, bootstrap, bootstrap_rep,
+                                             bootstrap_confidence)
+
+        cv_tracker.log_best_model(self._strengths, self.coeffs.tolist(),
+                                  self.score(),
+                                  self.bootstrap_coeffs)
+
+        return coeffs, cv_tracker
+
+    # Internals
+    def _prefit(self, features, labels, censoring):
+        n_intervals, n_features = features[0].shape
+        n_cases = len(features)
+        censoring = check_censoring_consistency(censoring, n_cases)
+        features = check_longitudinal_features_consistency(features,
+                                                           (n_intervals,
+                                                            n_features),
+                                                           "float64")
+        labels = check_longitudinal_features_consistency(labels,
+                                                         (n_intervals,),
+                                                         "int32")
+        self._set('n_features', n_features)
+        self._set('n_intervals', n_intervals)
+
+        features, labels, censoring = self._preprocess_data(features,
+                                                            labels,
+                                                            censoring)
+        n_coeffs = int(np.sum(self._n_lags) + self.n_features)
+        self._set('n_coeffs', n_coeffs)
+        self._set('coeffs', np.zeros(n_coeffs))
+        self._set('n_cases', len(features))
+
+        # Step computation
+        self._set("_model_obj", self._construct_model_obj())
+        self._model_obj.fit(features, labels, censoring)
+        if self.step is None:
+            self.step = 1 / self._model_obj.get_lip_max()
+
+        return features, labels, censoring
+
+    def _fit(self, project):
+        prox_obj = self._construct_prox_obj(self.coeffs, project)
+        solver_obj = self._solver_obj
+        model_obj = self._model_obj
+
+        # Now, we can pass the model and prox objects to the solver
+        solver_obj.set_model(model_obj).set_prox(prox_obj)
+
+        coeffs_start = self.coeffs
+
+        # Launch the solver
+        coeffs = solver_obj.solve(coeffs_start, step=self.step)
+
+        self._set("coeffs", coeffs)
+        self._set("_fitted", True)
+
+        return coeffs
+
+    def _postfit(self, p_features, p_labels, p_censoring,
+                 refit, bootstrap, bootstrap_rep, bootstrap_confidence):
+        # WARNING: _refit uses already preprocessed p_features, p_labels
+        # and p_censoring
+        if not self._fitted:
+            raise RuntimeError('You must fit the model first')
+
+        if refit:
+            # refit coeffs on all the data (after Cross Validation for example)
+            self._model_obj.fit(p_features, p_labels, p_censoring)
+            coeffs = self._fit(project=False)
+            self._set('coeffs', coeffs)
+
+        if bootstrap:
+            self._model_obj.fit(p_features, p_labels, p_censoring)
+            refit_coeffs = self._fit(project=True)
+            bootstrap_ci = self._bootstrap(p_features, p_labels, p_censoring,
+                                           refit_coeffs, bootstrap_rep,
+                                           bootstrap_confidence)
+            self._set('bootstrap_coeffs', bootstrap_ci._asdict())
+
+        return self.coeffs, self.bootstrap_coeffs
+
+    # Utilities #
+    def _preprocess_data(self, features, labels, censoring):
+        for preprocessor in self._preprocessor_obj:
+            features, labels, censoring = preprocessor.fit_transform(
+                features,
+                labels,
+                censoring)
+        return features, labels, censoring
+
+    def _bootstrap(self, p_features, p_labels, p_censoring, coeffs,
+                   rep, confidence):
+        # WARNING: _bootstrap inputs are already preprocessed p_features,
+        # p_labels and p_censoring
+        if confidence <= 0 or confidence >= 1:
+            raise ValueError("`bootstrap_confidence` should be in (0, 1)")
+        confidence = 1 - confidence
+        if not self._fitted:
+            raise RuntimeError('You must fit the model first')
+
+        bootstrap_coeffs = []
+        sim = SimuSCCS(self.n_cases, self.n_intervals, self.n_features,
+                       self.n_lags, coeffs=coeffs)
+        # TODO later: parallelize bootstrap (everything should be pickable...)
+        for k in range(rep):
+            y = sim._simulate_multinomial_outcomes(p_features, coeffs)
+            self._model_obj.fit(p_features, y, p_censoring)
+            bootstrap_coeffs.append(self._fit(True))
+
+        bootstrap_coeffs = np.exp(np.array(bootstrap_coeffs))
+        bootstrap_coeffs.sort(axis=0)
+        lower_bound = np.log(bootstrap_coeffs[
+                                 int(np.floor(rep * confidence / 2))])
+        upper_bound = np.log(bootstrap_coeffs[
+                                 int(np.floor(rep * (1 - confidence / 2)))])
+        median_coeffs = np.log(bootstrap_coeffs[
+                                   int(np.floor(rep * .5))])
+        return Bootstrap_CI(coeffs, median_coeffs, lower_bound,
+                            upper_bound, confidence)
+
+    def _score(self, features=None, labels=None, censoring=None,
+               preprocess=False):
+        if not self._fitted:
+            raise RuntimeError('You must fit the model first')
+
+        all_none = all(e is None for e in [features, labels, censoring])
+        if all_none:
+            loss = self._model_obj.loss(self.coeffs)
+        else:
+            if features is None:
+                raise ValueError('Passed ``features`` is None')
+            elif labels is None:
+                raise ValueError('Passed ``labels`` is None')
+            elif censoring is None:
+                raise ValueError('Passed ``censoring`` is None')
+            else:
+                # Avoid calling preprocessing during CV
+                if preprocess:
+                    features, labels, censoring = self._preprocess_data(
+                        features,
+                        labels,
+                        censoring)
+                model = self._construct_model_obj().fit(features, labels,
+                                                        censoring)
+                loss = model.loss(self.coeffs)
+        return loss
+
+    # Factories #
+    def _construct_preprocessor_obj(self):
+        # TODO later: fix parallel preprocessing
+        preprocessors = list()
+        preprocessors.append(LongitudinalSamplesFilter(n_jobs=1))
+        if len(self.n_lags) > 0:
+            preprocessors.append(LongitudinalFeaturesLagger(self.n_lags,
+                                                            n_jobs=1))
+        return preprocessors
+
+    def _construct_model_obj(self):
+        return ModelSCCS(self.n_intervals, self.n_lags)
+
+    def _construct_prox_obj(self, coeffs=None, project=False):
+        n_penalized_features = len(self.penalized_features) \
+            if self.penalized_features is not None else 0
+
+        if project:
+            # project future coeffs on the support of given coeffs
+            if all(self.n_lags) == 0:
+                proxs = [ProxZero()]
+            elif coeffs is not None and any(self.n_lags) > 0:
+                prox_ranges = self._detect_support(coeffs)
+                proxs = [ProxEquality(0, range=r) for r in prox_ranges]
+            else:
+                raise ValueError("Coeffs are None. " +
+                                 "Equality penalty cannot infer the "
+                                 "coefficients support.")
+        elif n_penalized_features > 0 and self._strength_tv is not None or \
+                self._strength_group_l1 is not None:
+            # TV and GroupLasso penalties
+            blocks_start = np.zeros(n_penalized_features)
+            blocks_end = np.zeros(n_penalized_features)
+            proxs = []
+
+            for i in self.penalized_features:
+                start = int(self._features_offset[i])
+                blocks_start[i] = start
+                end = int(blocks_start[i] + self._n_lags[i] + 1)
+                blocks_end[i] = end
+                if self._strength_tv is not None:
+                    proxs.append(ProxTV(self._strength_tv, range=(start, end)))
+
+            if self._strength_group_l1 is not None:
+                blocks_size = blocks_end - blocks_start
+                proxs.append(ProxGroupL1(self._strength_group_l1,
+                                         blocks_start.tolist(),
+                                         blocks_size.tolist()))
+        else:
+            # Default prox: does nothing
+            proxs = [ProxZero()]
+
+        prox_obj = ProxMulti(tuple(proxs))
+
+        return prox_obj
+
+    def _detect_support(self, coeffs):
+        """Return the ranges over which consecutive coefficients are equal in
+        case at least two coefficients are equal.
+
+        This method is used to compute the ranges for ProxEquality,
+        to enforce a support corresponding to the support of `coeffs`.
+
+         example:
+         coeffs = np.array([ 1.  2.  2.  1.  1.])
+         self._detect_support(coeffs)
+         >>> [(1, 3), (3, 5)]
+         """
+        kernel = np.array([1, -1])
+        groups = []
+        for i in self.penalized_features:
+            idx = int(self._features_offset[i])
+            n_lags = int(self._n_lags[i])
+            if n_lags > 0:
+                acc = 1
+                for change in np.convolve(coeffs[idx:idx+n_lags+1], kernel,
+                                          'valid'):
+                    if change:
+                        if acc > 1:
+                            groups.append((idx, idx + acc))
+                        idx += acc
+                        acc = 1
+                    else:
+                        acc += 1
+                # Last coeff always count as a change
+                if acc > 1:
+                    groups.append((idx, idx + acc))
+        return groups
+
+    @staticmethod
+    def _construct_solver_obj(step, max_iter, tol, print_every,
+                              record_every, verbose, seed):
+        # seed cannot be None in SVRG
+        solver_obj = SVRG(step=step, max_iter=max_iter, tol=tol,
+                          print_every=print_every,
+                          record_every=record_every,
+                          verbose=verbose, seed=seed)
+
+        return solver_obj
+
+    def _construct_generator_obj(self, strength_tv_range,
+                                 strength_group_l1_range,
+                                 logspace=True):
+        generators = []
+        if len(strength_tv_range) == 2:
+            if logspace:
+                generators.append(Log10UniformGenerator(*strength_tv_range))
+            else:
+                generators.append(uniform(strength_tv_range))
+        else:
+            generators.append(null_generator)
+
+        if len(strength_group_l1_range) == 2:
+            if logspace:
+                generators.append(
+                    Log10UniformGenerator(*strength_group_l1_range))
+            else:
+                generators.append(uniform(strength_group_l1_range))
+        else:
+            generators.append(null_generator)
+
+        return generators
+
+    # Properties #
+    @property
+    def step(self):
+        return self._step_size
+
+    @step.setter
+    def step(self, value):
+        self._set('_step_size', value)
+        self._solver_obj.step = value
+
+    @property
+    def _strengths(self):
+        return Strengths(self._strength_tv,
+                         self._strength_group_l1)
+
+    @_strengths.setter
+    def _strengths(self, value):
+        if len(value) == 2:
+            self.strength_tv = value[0]
+            self.strength_group_l1 = value[1]
+        else:
+            raise ValueError('strength should be a tuple of length 2.')
+
+    @property
+    def strength_tv(self):
+        return self._strength_tv
+
+    @strength_tv.setter
+    def strength_tv(self, value):
+        if value is None or isinstance(value, float) and value > 0:
+            self._set('_strength_tv', value)
+        else:
+            raise ValueError(
+                'strength_tv should be a float greater than zero.')
+
+    @property
+    def strength_group_l1(self):
+        return self._strength_tv
+
+    @strength_group_l1.setter
+    def strength_group_l1(self, value):
+        if value is None or isinstance(value, float) and value > 0:
+            self._set('_strength_group_l1', value)
+        else:
+            raise ValueError('strength_group_l1 should be a float greater '
+                             'than zero.')
+
+    @property
+    def random_state(self):
+        return self._random_state
+
+    @random_state.setter
+    def random_state(self, value):
+        np.random.seed(value)
+        self._set('_random_state', value)
+
+    @property
+    def n_lags(self):
+        return self._n_lags
+
+    @n_lags.setter
+    def n_lags(self, value):
+        offsets = [0]
+        for l in value:
+            offsets.append(offsets[-1] + l + 1)
+        self._set('_n_lags', value)
+        self._set('_features_offset', offsets)
+        self._construct_preprocessor_obj()
+
+    @property
+    def penalized_features(self):
+        return self._penalized_features
+
+    @penalized_features.setter
+    def penalized_features(self, value):
+        self._set('_penalized_features', value)
+        self._construct_preprocessor_obj()
+
+
+# TODO later: put the code below somewhere else?
+class CrossValidationTracker:
+    def __init__(self, global_params: dict):
+        self.global_params = global_params
+        self.cv_params = list()
+        self.cv_train_scores = list()
+        self.cv_mean_train_scores = list()
+        self.cv_sd_train_scores = list()
+        self.cv_test_scores = list()
+        self.cv_mean_test_scores = list()
+        self.cv_sd_test_scores = list()
+        self.best_model = {
+            'strength': list(),
+            'coeffs': list(),
+            'bootstrap_ci': {}
+        }
+
+    def log_cv_iteration(self, cv_params, cv_train_score, cv_test_score):
+        self.cv_params.append(cv_params)
+        self.cv_train_scores.append(list(cv_train_score))
+        self.cv_mean_train_scores.append(cv_train_score.mean())
+        self.cv_sd_train_scores.append(cv_train_score.std())
+        self.cv_test_scores.append(list(cv_test_score))
+        self.cv_mean_test_scores.append(cv_test_score.mean())
+        self.cv_sd_test_scores.append(cv_test_score.std())
+
+    def find_best_params(self):
+        # Find best parameters
+        best_idx = int(np.argmin(self.cv_mean_test_scores))
+        return self.cv_params[best_idx]
+
+    def log_best_model(self, strength, coeffs, score, bootstrap_ci_dict):
+        self.best_model = {
+            'strength': strength,
+            'coeffs': list(coeffs),
+            'score': score,
+            'bootstrap_ci': bootstrap_ci_dict
+        }
+
+    def todict(self):
+        return {'global_model_parameters': list(self.global_params),
+                'cv_params': list(self.cv_params),
+                'cv_train_scores': list(self.cv_train_scores),
+                'cv_mean_train_scores': list(self.cv_mean_train_scores),
+                'cv_sd_train_scores': list(self.cv_sd_train_scores),
+                'cv_test_scores': list(self.cv_test_scores),
+                'cv_mean_test_scores': list(self.cv_mean_test_scores),
+                'cv_sd_test_scores': list(self.cv_sd_test_scores),
+                'best_model': self.best_model
+                }
+
+    def plot_cv_report(self, elevation=25, azimuth=35):
+        group_l1_strength = [p['strength'].strength_group_l1 for p in
+                             self.cv_params]
+        tv_strength = [p['strength'].strength_tv for p in
+                       self.cv_params]
+        if not any(group_l1_strength) is None and not any(tv_strength) is None:
+            return self.plot_learning_curves_contour(elevation, azimuth)
+        elif not any(group_l1_strength) is None:
+            return self.plot_learning_curves('Group L1')
+        elif not any(tv_strength) is None:
+            return self.plot_learning_curves('TV')
+        else:
+            raise ValueError("Logged Group L1 and TV strengths are None.")
+
+    def plot_learning_curves(self, hyperparameter):
+        #TODO: test this method
+        if hyperparameter == "TV":
+            strength = [p['strength'].strength_tv for p in
+                        self.cv_params]
+        elif hyperparameter == "Group L1":
+            strength = [p['strength'].strength_group_l1 for p in
+                        self.cv_params]
+        else:
+            raise ValueError("hyperparameter value should be either `TV` or"
+                             " `Group L1`")
+        x = np.log10(strength)
+        order = np.argsort(x)
+        m = np.array(self.cv_mean_train_scores)[order]
+        sd = np.array(self.cv_sd_train_scores)[order]
+        fig, ax = plt.figure()
+
+        p1 = ax.plot(x[order], m)
+        p2 = ax.fill_between(x[order], m - sd, m + sd, alpha=.3)
+        min_point_train = np.min(m - sd)
+        m = np.array(self.cv_mean_test_scores)[order]
+        sd = np.array(self.cv_sd_test_scores)[order]
+        p3 = ax.plot(x[order], m)
+        p4 = ax.fill_between(x[order], m - sd, m + sd, alpha=.3)
+        min_point_test = np.min(m - sd)
+        min_point = min(min_point_train, min_point_test)
+        p5 = plt.scatter(np.log10(strength), min_point*np.ones_like(strength))
+
+        ax.legend([(p1[0], p2), (p3[0], p4), p5],
+                  ['train score', 'test score', 'tested hyperparameters'],
+                  loc='lower right')
+        ax.set_title('Learning curves')
+        ax.set_xlabel('Strength %s (log scale)' % hyperparameter)
+        ax.set_ylabel('Loss')
+        return fig, ax
+
+    def plot_learning_curves_contour(self, elevation=25, azimuth=35):
+        """‘elev’ stores the elevation angle in the z plane.
+        ‘azim’ stores the azimuth angle in the x,y plane."""
+        sc_train = self.cv_mean_train_scores
+        sc_test = self.cv_mean_test_scores
+        group_l1_strength = [p['strength'].strength_group_l1 for p in
+                             self.cv_params]
+        tv_strength = [p['strength'].strength_tv for p in
+                       self.cv_params]
+        X_tile = np.log10(tv_strength)
+        Y_tile = np.log10(group_l1_strength)
+
+        fig, axarr = plt.subplots(1, 3, figsize=(12, 4), sharey=True,
+                                  sharex=True)
+
+        ax = axarr[-1]
+        ax.scatter(np.log10(tv_strength), np.log10(group_l1_strength))
+        ax.set_title("Random search tested hyperparameters")
+        ax.set_xlabel('Strength TV')
+        ax.set_ylabel('Strength Group L1')
+
+        names = ['train', 'test']
+        cmaps = [cm.Blues, cm.Greens]
+
+        for i, cv in enumerate([sc_train, sc_test]):
+            Z = np.array(cv)
+            ax = axarr[i]
+            cax = ax.tricontourf(X_tile, Y_tile, Z, 50, cmap=cmaps[i])
+            ax.set_title(r'Loss (%s)' % names[i])
+            ax.set_xlabel("TV strength (log)")
+            idx = np.where(Z == Z.min())
+            x, y = (X_tile[idx][0], Y_tile[idx][0])
+            ax.scatter(x, y, color="red", marker="x")
+            ax.text(x, y, r'%.2f' % Z.min(), color="red", fontsize=12)
+
+        axarr[0].set_ylabel("Group L1 strength (log)")
+        plt.tight_layout()
+
+        fig2 = plt.figure(figsize=(8, 6.5))
+        ax = Axes3D(fig2)
+        colors = ['blue', 'green']
+        names = ['train', 'test']
+        proxies = []
+        proxy_names = []
+        for i, cv in enumerate([sc_train, sc_test]):
+            Z = np.array(cv)
+            ax.plot_trisurf(X_tile, Y_tile, Z, alpha=0.3, color=colors[i])
+            proxies.append(plt.Rectangle((0, 0), 1, 1, fc=colors[i], alpha=.3))
+            proxy_names.append("%s score" % names[i])
+
+        Z = np.array(sc_test)
+        x, y = np.log10(
+            np.array(
+                self.find_best_params()['strength']).astype(
+                np.float))
+        idx = np.where(X_tile == x)  # should be equal to np.where(Y_tile == y)
+        z = Z[idx]
+        p1 = ax.scatter(x, y, z, c='red')
+        proxies.append(p1)
+        proxy_names.append('CV best score')
+
+        x, y = np.log10(
+            np.array(
+                self.find_best_params()['strength']).astype(
+                np.float))
+        idx = np.where(X_tile == x)  # should be equal to np.where(Y_tile == y)
+        z = Z[idx]
+        p2 = ax.scatter(x, y, z, c='magenta')
+        proxies.append(p2)
+        proxy_names.append('CV best score')
+
+        ax.set_xlabel("TV strength (log)")
+        ax.set_ylabel("Group L1 strength (log)")
+        ax.set_title("Learning surfaces")
+        ax.set_zlabel("loss")
+        ax.view_init(elevation, azimuth)
+        plt.legend(proxies, proxy_names, loc='best')
+        return fig, axarr, fig2, ax
+
+
+# Generators for random search
+# generator which generates nothing
+DumbGenerator = namedtuple('DumbGenerator', ['rvs'])
+
+null_generator = DumbGenerator(rvs=lambda x: [None])
+
+
+class Log10UniformGenerator:
+    """Generate uniformly distributed points in the log10 space."""
+    def __init__(self, min_val, max_val):
+        self.min_val = min_val
+        self.max_val = max_val
+        self.gen = uniform(0, 1)
+
+    def rvs(self, n):
+        return 10 ** (
+            self.min_val + (self.max_val - self.min_val) * self.gen.rvs(n))

--- a/tick/survival/model_sccs.py
+++ b/tick/survival/model_sccs.py
@@ -8,8 +8,8 @@ from tick.preprocessing.utils import check_longitudinal_features_consistency, \
 
 
 class ModelSCCS(ModelFirstOrder, ModelLipschitz):
-    """SCCS model. This class gives first order information (gradient and loss)
-    for this model.
+    """Discrete-time Self Control Case Series (SCCS) likelihood. This class
+    provides first order information (gradient and loss) model.
 
     Parameters
     ----------

--- a/tick/survival/model_sccs.py
+++ b/tick/survival/model_sccs.py
@@ -16,32 +16,32 @@ class ModelSCCS(ModelFirstOrder, ModelLipschitz):
     n_intervals : `int`
         Number of time intervals observed for each sample.
 
-    n_lags : `int`
-        Number of lags. The model will regress labels on the last observed
-        values of the features over the `n_lags` time intervals. `n_lags`
-        must be between 0 and `n_intervals` - 1
+    n_lags : `numpy.ndarray`, shape=(n_features,), dtype="uint64"
+        Number of lags per feature. The model will regress labels on the last
+        observed values of the features over the corresponding `n_lags` time
+        intervals. `n_lags` values must be between 0 and `n_intervals` - 1.
 
     Attributes
     ----------
     features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
-        list of length n_samples, each element of the list of
+        list of length n_cases, each element of the list of
         shape=(n_intervals, n_features)
         The list of features matrices.
 
     labels : `list` of `numpy.ndarray`,
-        list of length n_samples, each element of the list of 
+        list of length n_cases, each element of the list of
         shape=(n_intervals,)
         The labels vector
-        
-    censoring : `numpy.ndarray`, shape=(n_samples,), dtype="uint64"
+
+    censoring : `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
         The censoring data. This array should contain integers in
         [1, n_intervals]. If the value i is equal to n_intervals, then there
         is no censoring for sample i. If censoring = c < n_intervals, then
         the observation of sample i is stopped at interval c, that is, the
-        row c - 1 of the correponding matrix. The last n_intervals - c rows
+        row c - 1 of the corresponding matrix. The last n_intervals - c rows
         are then set to 0.
 
-    n_samples : `int` (read-only)
+    n_cases : `int` (read-only)
         Number of samples
 
     n_features : `int` (read-only)
@@ -51,43 +51,31 @@ class ModelSCCS(ModelFirstOrder, ModelLipschitz):
         Total number of coefficients of the model
     """
 
-    _attrinfos = {
-        "labels": {
-            "writable": False
-        },
-        "features": {
-            "writable": False
-        },
-        "censoring": {
-            "writable": False
-        },
-        "n_features": {
-            "writable": False
-        },
-        "n_samples": {
-            "writable": False
-        },
-        "n_lags": {
-            "writable": False
-        },
-        "n_intervals": {
-            "writable": False
-        }
-    }
+    _const_attr = [
+        "labels",
+        "features",
+        "censoring",
+        "n_features",
+        "n_cases",
+        "n_lags",
+        "n_intervals"
+    ]
 
-    def __init__(self, n_intervals: int, n_lags: int):
-        if n_lags >= n_intervals:
-            raise ValueError("n_lags should be < n_intervals")
+    _attrinfos = {key: {'writable': False} for key in _const_attr}
 
+    def __init__(self, n_intervals: int, n_lags: np.array):
         ModelFirstOrder.__init__(self)
         ModelLipschitz.__init__(self)
-        self.n_lags = n_lags
         self.n_intervals = n_intervals
+        self.n_features = len(n_lags)
+        self.n_lags = n_lags
+        for n_l in n_lags:
+            if n_l >= n_intervals:
+                raise ValueError("n_lags should be < n_intervals")
         self.labels = None
         self.features = None
         self.censoring = None
-        self.n_features = None
-        self.n_samples = None
+        self.n_cases = None
 
     def fit(self, features, labels, censoring=None):
         """Set the data into the model object.
@@ -100,8 +88,8 @@ class ModelSCCS(ModelFirstOrder, ModelLipschitz):
 
         labels : List[{1d array, csr matrix of shape (n_intervals,)]
             The labels vector
-            
-        censoring : 1d array of shape (n_samples,)
+
+        censoring : 1d array of shape (n_cases,)
             The censoring vector
 
         Returns
@@ -126,16 +114,16 @@ class ModelSCCS(ModelFirstOrder, ModelLipschitz):
         Parameters
         ----------
         features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
-            list of length n_samples, each element of the list of
+            list of length n_cases, each element of the list of
             shape=(n_intervals, n_features)
             The list of features matrices.
 
         labels : `list` of `numpy.ndarray`,
-            list of length n_samples, each element of the list of 
+            list of length n_cases, each element of the list of
             shape=(n_intervals,)
             The labels vector
-        
-        censoring : `numpy.ndarray`, shape=(n_samples,), dtype="uint64"
+
+        censoring : `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
             The censoring data. This array should contain integers in
             [1, n_intervals]. If the value i is equal to n_intervals, then there
             is no censoring for sample i. If censoring = c < n_intervals, then
@@ -143,20 +131,26 @@ class ModelSCCS(ModelFirstOrder, ModelLipschitz):
             row c - 1 of the correponding matrix. The last n_intervals - c rows
             are then set to 0.
         """
-        n_intervals, n_features = features[0].shape
+        n_intervals, n_coeffs = features[0].shape
+        n_lags = self.n_lags
         self._set("n_intervals", n_intervals)
-        self._set("n_features", n_features)
-        self._set("n_samples", len(features))
-        if len(labels) != self.n_samples:
+        self._set("n_coeffs", n_coeffs)
+        # TODO: implement checker as outside function
+        # if n_lags > 0 and n_coeffs % (n_lags + 1) != 0:
+        #     raise ValueError("(n_lags + 1) should be a divisor of n_coeffs")
+        # else:
+        #     self._set("n_features", int(n_coeffs / (n_lags + 1)))
+        self._set("n_cases", len(features))
+        if len(labels) != self.n_cases:
             raise ValueError("Features and labels lists should have the same\
              length.")
         if censoring is None:
-            censoring = np.full(self.n_samples, self.n_intervals,
+            censoring = np.full(self.n_cases, self.n_intervals,
                                 dtype="uint64")
-        censoring = check_censoring_consistency(censoring, self.n_samples)
+        censoring = check_censoring_consistency(censoring, self.n_cases)
         features = check_longitudinal_features_consistency(features,
                                                            (n_intervals,
-                                                            n_features),
+                                                            n_coeffs),
                                                            "float64")
         labels = check_longitudinal_features_consistency(labels,
                                                          (self.n_intervals,),

--- a/tick/survival/simu_sccs.py
+++ b/tick/survival/simu_sccs.py
@@ -1,305 +1,386 @@
 # License: BSD 3 clause
 
 from operator import itemgetter
-
 import numpy as np
 import scipy.sparse as sps
 from scipy.sparse import csr_matrix
-
 from tick.base.simulation import Simu
-from tick.preprocessing.longitudinal_features_lagger\
-    import LongitudinalFeaturesLagger
+from tick.hawkes import SimuHawkesExpKernels, SimuHawkesMulti
+from tick.preprocessing import LongitudinalFeaturesLagger
+from itertools import permutations
+from copy import deepcopy
+from scipy.stats import beta, norm, truncnorm, wald
 
 
 class SimuSCCS(Simu):
-    """Simulation of a Self Control Case Series (SCCS) model. This simulator can
-    produce exposure (features), outcomes (labels) and censoring data. 
-     
-    The features matrices  are a `n_sample` list of numpy arrays (dense case) or 
-    csr_matrices (sparse case) of shape `(n_intervals, n_features)` containing
-    exposures to each feature.
-    Exposure can take two forms:
-    - short repeated exposures: in that case, each column of the numpy arrays 
-    or csr matrices can contain multiple ones, each one representing an exposure
-    for a particular time bucket.
-    - infinite unique exposures: in that case, each column of the numpy arrays
-    or csr matrices can only contain a single one, corresponding to the starting
-    date of the exposure.
+    _const_attr = [
+        # user defined parameters
+        '_exposure_type',
+        '_outcome_distribution',
+        '_censoring_prob',
+        '_censoring_scale',  # redundant with prob ?
+        '_batch_size',
+        '_distribution',
+        # user defined or computed attributes
+        '_hawkes_exp_kernel',
+        '_coeffs',
+        '_time_drift'
+    ]
 
-    Parameters
-    ----------
-    n_samples : `int`,
-        Number of samples to generate.
-    
-    n_intervals : `int`
-        Number of time intervals used to generate features and outcomes.
-         
-    n_lags : `int`
-        Number of lags to be used when simulating the outcomes. The output
-        features are returned without lagging to allow the testing of lag
-        misspecification in the model.
+    _attrinfos = {key: {'writable': False} for key in _const_attr}
+    _attrinfos['hawkes_obj'] = {'writable': True}
 
-    sparse : `boolean`, default=True
-        Generate sparse or dense features.
-     
-    exposure_type : {'infinite', 'short'}, default='infinite'
-        Either 'infinite' for infinite unique exposures or 'short' for short
-        repeated exposures.
-        
-    distribution : {'multinomial', 'poisson'}, default='multinomial'
-        Dristribution used to generate the outcomes. In the 'multinomial' case,
-        the Poisson process used to generate the events is conditionned by total 
-        the number event per sample, which is set to be equal to one. In that
-        case, the simulation matches exactly the SCCS model hypotheses. In the
-        'poisson' case, the outcomes are generated from a Poisson process, which
-        can result in more than one outcome tick per sample. See 
-        `first_tick_only` option to filter out additional events.
-        
-    first_tick_only : `Boolean`, default=True
-        Keep only the first event and drop the consecutive ones when simulating
-        with Poisson distribution. 
-        
-    censoring : `Boolean`, default=True
-        Simulate a censoring vector. In that case, the features and outcomes are
-        simulated, then right-censored according to the simulated censoring
-        dates.
-        
-    censoring_prob : `float`, default=.7
-        Probability that a sample is censored. Should be in [0, 1].
-        
-    censoring_intensity : `float`, default=.9
-        The number of censored time intervals are drawn from a Poisson 
-        distribution with intensity equal to `censoring_intensity`. The higher,
-        the more intervals will be censored. Should be greater than 0.
-        
-    coeffs : `numpy.ndarray` of shape (n_features * (n_lags + 1)), default=None
-        Can be used to provide your own set of coefficients. If set to None, the
-        simulator will generate coefficients randomly.
-        
-    seed : `int`
-        The seed of the random number generator
-        
-    verbose : `bool`
-        If True, print things
-        
-    batch_size : `int`, default=None
-        When generating outcomes with Poisson distribution, the simulator will
-        discard samples to which no event has occured. In this case, the
-        simulator generate successive batches of samples, until it reaches 
-        a total of n_samples. This parameter can be used to set the batch size.
-        
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from tick.survival import SimuSCCS
-    >>> sim = SimuSCCS(n_samples=2, n_intervals=3, n_features=2, n_lags=2,
-    ... seed=42, sparse=False, exposure_type="short")
-    >>> features, labels, censoring, coeffs = sim.simulate()
-    --------------------------------------
-    Launching simulation using SimuSCCS...
-    >>> print(features)
-    [array([[ 0.,  0.],
-           [ 1.,  0.],
-           [ 1.,  1.]]), array([[ 1.,  1.],
-           [ 1.,  1.],
-           [ 1.,  1.]])]
-    >>> print(labels)
-    [array([0, 0, 1], dtype=int32), array([0, 0, 1], dtype=int32)]
-    >>> print(censoring)
-    [3 3]
-    >>> print(coeffs)
-    [ 0.54738557 -0.15109073  0.71345739  1.67633284 -0.25656871 -0.25655065]
-     """
+    def __init__(self, n_cases, n_intervals, n_features, n_lags,
+                 time_drift=None, exposure_type="single_exposure",
+                 distribution="multinomial", sparse=True,
+                 censoring_prob=0, censoring_scale=None,
+                 coeffs=None, hawkes_exp_kernels=None, n_correlations=0,
+                 batch_size=None, seed=None, verbose=True,
+                 ):
+        """Simulation of a Self Control Case Series (SCCS) model. This simulator can
+        produce exposure (features), outcomes (labels) and censoring data.
+        The features matrices  are a `n_cases` list of numpy arrays (dense case) or
+        csr_matrices (sparse case) of shape `(n_intervals, n_features)` containing
+        exposures to each feature.
+        Exposure can take two forms:
+        - short repeated exposures: in that case, each column of the numpy arrays
+        or csr matrices can contain multiple ones, each one representing an exposure
+        for a particular time bucket.
+        - infinite unique exposures: in that case, each column of the numpy arrays
+        or csr matrices can only contain a single one, corresponding to the starting
+        date of the exposure.
 
-    _attrinfos = {
-        "_exposure_type": {
-            "writable": False
-        },
-        "_distribution": {
-            "writable": False
-        },
-        "_censoring_prob": {
-            "writable": False
-        },
-        "_censoring_intensity": {
-            "writable": False
-        },
-        "_coeffs": {
-            "writable": False
-        },
-        "_batch_size": {
-            "writable": False
-        }
-    }
+        Parameters
+        ----------
+        n_cases : `int`
+            Number of cases to generate. A case is a sample who experience at
+            least one adverse event.
 
-    def __init__(self, n_samples, n_intervals, n_features, n_lags, coeffs=None,
-                 sparse=True, exposure_type="infinite",
-                 distribution="multinomial", first_tick_only=True,
-                 censoring=True, censoring_prob=.7, censoring_intensity=.9,
-                 seed=None, verbose=True, batch_size=None):
+        n_intervals : `int`
+            Number of time intervals used to generate features and outcomes.
+
+        n_features : `int`
+            Number of features to simulate for each case.
+
+        n_lags : `numpy.ndarray`, shape=(n_features,), dtype="uint64"
+           Number of lags per feature. The model will regress labels on the
+           last observed values of the features over their corresponding
+           `n_lags` time intervals. `n_lags` values must be between 0 and
+           `n_intervals` - 1.
+
+        exposure_type : {'infinite', 'short'}, default='infinite'
+           Either 'infinite' for infinite unique exposures or 'short' for short
+           repeated exposures.
+
+        distribution : {'multinomial', 'poisson'}, default='multinomial'
+           Distribution used to generate the outcomes. In the 'multinomial'
+           case, the Poisson process used to generate the events is conditionned
+           by total the number event per sample, which is set to be equal to
+           one. In that case, the simulation matches exactly the SCCS model
+           hypotheses. In the 'poisson' case, the outcomes are generated from a
+           Poisson process, which can result in more than one outcome tick per
+           sample. In this case, the first event is kept, and the other are
+           discarded.
+
+        sparse : `boolean`, default=True
+            Generate sparse or dense features.
+
+        censoring : `Boolean`, default=True
+           Simulate a censoring vector. In that case, the features and outcomes are
+           simulated, then right-censored according to the simulated censoring
+           dates.
+
+        censoring_prob : `float`, default=0.
+           Probability that a sample is censored. Should be in [0, 1]. If 0, no
+           censoring is applied.
+
+        censoring_scale : `float`, default=None
+           The number of censored time intervals are drawn from a Poisson
+           distribution with intensity equal to `censoring_scale`. The higher,
+           the more intervals will be censored. If None, no censoring is
+           applied.
+
+        coeffs : `numpy.ndarray` of shape (n_features + (n_lags + 1).sum()), default=None
+           Can be used to provide your own set of coefficients. If set to None,
+           the simulator will generate coefficients randomly.
+
+        hawkes_exp_kernels : `SimuHawkesExpKernels`, default=None
+            Features are simulated with exponential kernel Hawkes proecesses.
+            This parameter can be used to specify your own kernels (see
+            `SimuHawkesExpKernels` documentation). If None, random kernels
+            are generated. The same kernels are used to generate features for
+            the whole generated population.
+
+        n_correlations : `int`, default=0
+            If `hawkes_exp_kernels` is None, random kernels are generated. This
+            parameter controls the number of non-null non-diagonal kernels.
+
+        batch_size : `int`, default=None
+           When generating outcomes with Poisson distribution, the simulator will
+           discard samples to which no event has occured. In this case, the
+           simulator generate successive batches of samples, until it reaches
+           a total of n_samples. This parameter can be used to set the batch size.
+
+        seed : `int`, default=None
+            The seed of the random number generator
+
+        verbose : `bool`, default=True
+            If True, print things
+
+        Examples
+        --------
+        >>> from tick.survival import SimuSCCS
+        >>> n_lags = np.repeat(2, 2).astype('uint64')
+        >>> sim = SimuSCCS(n_cases=5, n_intervals=3, n_features=2, n_lags=n_lags,
+        ... seed=42, sparse=False, exposure_type="single_exposure",
+        ... verbose=False)
+        >>> features, labels, censoring, coeffs = sim.simulate()
+        >>> print(features)
+        [array([[ 0.,  0.],
+               [ 1.,  0.],
+               [ 1.,  1.]]), array([[ 1.,  1.],
+               [ 1.,  1.],
+               [ 1.,  1.]])]
+        >>> print(labels)
+        [array([0, 0, 1], dtype=int32), array([0, 0, 1], dtype=int32)]
+        >>> print(censoring)
+        [3 3]
+        >>> print(coeffs)
+        [ 0.54738557 -0.15109073  0.71345739  1.67633284 -0.25656871 -0.25655065]
+        """
+
         super(SimuSCCS, self).__init__(seed, verbose)
-        self.n_samples = n_samples
+        self.n_cases = n_cases
         self.n_intervals = n_intervals
         self.n_features = n_features
         self.n_lags = n_lags
         self.sparse = sparse
-        self.first_tick_only = first_tick_only
-        self.censoring = censoring
+
+        self.hawkes_obj = None
+
+        # attributes with restricted value range
+        self._exposure_type = None
         self.exposure_type = exposure_type
+
+        self._distribution = None
         self.distribution = distribution
+
+        self._censoring_prob = 0
         self.censoring_prob = censoring_prob
-        self.censoring_intensity = censoring_intensity
+
+        self._censoring_scale = None
+        self.censoring_scale = censoring_scale if censoring_scale \
+            else n_intervals / 4
+
+        self._coeffs = None
         self.coeffs = coeffs
+
+        self._batch_size = None
         self.batch_size = batch_size
 
+        # TODO later: add properties for these parameters
+        self.n_correlations = n_correlations
+        self.hawkes_exp_kernels = hawkes_exp_kernels
+        self.time_drift = time_drift  # function(t), used only for the paper, allow to add a baseline
+        # TODO: make a property from this baseline
+
     def simulate(self):
-        """
-        Launch simulation of the data.
+        """ Launch simulation of the data.
 
         Returns
         -------
         features : `list` of `numpy.ndarray` or `list` of `scipy.sparse.csr_matrix`,
-            list of length n_samples, each element of the list of 
+            list of length n_cases, each element of the list of
             shape=(n_intervals, n_features)
             The list of features matrices.
 
         labels : `list` of `numpy.ndarray`,
-            list of length n_samples, each element of the list of 
+            list of length n_cases, each element of the list of
             shape=(n_intervals,)
             The labels vector
-            
-        censoring : `numpy.ndarray`, shape=(n_samples,), dtype="uint64"
-            The censoring data. This array should contain integers in 
+
+        censoring : `numpy.ndarray`, shape=(n_cases,), dtype="uint64"
+            The censoring data. This array should contain integers in
             [1, n_intervals]. If the value i is equal to n_intervals, then there
-            is no censoring for sample i. If censoring = c < n_intervals, then 
-            the observation of sample i is stopped at interval c, that is, the 
+            is no censoring for sample i. If censoring = c < n_intervals, then
+            the observation of sample i is stopped at interval c, that is, the
             row c - 1 of the corresponding matrix. The last n_intervals - c rows
             are then set to 0.
-        
+
         coeffs : `numpy.ndarray`, shape=(n_features * (n_lags + 1),)
             The coefficients used to simulate the data.
         """
         return Simu.simulate(self)
 
     def _simulate(self):
-        """ Loop to generate batches of samples until n_samples is reached.
+        """ Loop to generate batches of samples until n_cases is reached.
         """
-        n_lagged_features = (self.n_lags + 1) * self.n_features
-        n_samples = self.n_samples
+        n_lagged_features = int(self.n_lags.sum() + self.n_features)
+        n_cases = self.n_cases
         if self.coeffs is None:
             self.coeffs = np.random.normal(1e-3, 1.1, n_lagged_features)
 
         features = []
+        censored_features = []
         outcomes = []
-        out_censoring = np.zeros((n_samples,), dtype="uint64")
-        sample_count = 0
-        while sample_count < n_samples:
-            X_temp, y_temp, _censoring, _ = self._simulate_batch()
-            n_new_samples = len(y_temp)
-            expected_count = sample_count + n_new_samples
-            if expected_count >= n_samples:
-                n = n_new_samples - (expected_count - n_samples)
-            else:
-                n = n_new_samples
+        censoring = np.zeros((n_cases,), dtype="uint64")
+        cases_count = 0
+        while cases_count < n_cases:
+            _features, _censored_features, _outcomes, _censoring, _n_samples = \
+                self._simulate_batch()
 
-            features.extend(X_temp[0:n])
-            outcomes.extend(y_temp[0:n])
-            out_censoring[sample_count:sample_count+n] = _censoring[0:n]
-            sample_count += n_new_samples
+            n_new_cases = _n_samples
+            c = cases_count
+            cases_count += n_new_cases
+            n = n_cases - c if cases_count >= n_cases else n_new_cases
 
-        return features, outcomes, out_censoring, self.coeffs
+            features.extend(_features[0:n])
+            censored_features.extend(_censored_features[0:n])
+            outcomes.extend(_outcomes[0:n])
+            censoring[c:c + n] = _censoring[0:n]
+
+        return features, censored_features, outcomes, censoring, self.coeffs
 
     def _simulate_batch(self):
         """Simulate a batch of samples, each of which have ticked at least once.
         """
-        _censoring = np.full((self.batch_size,), self.n_intervals,
+        _features, _n_samples = self.simulate_features(self.batch_size)
+        _censored_features = deepcopy(_features)
+        _outcomes = self.simulate_outcomes(_features)
+        _censoring = np.full((_n_samples,), self.n_intervals,
                              dtype="uint64")
-        # No censoring right now
-        X_temp = self._simulate_sccs_features(self.batch_size)
-        y_temp = self._simulate_outcomes(X_temp, _censoring)
-
-        if self.censoring:
+        if self.censoring_prob:
             censored_idx = np.random.binomial(1, self.censoring_prob,
-                                              size=self.batch_size
+                                              size=_n_samples
                                               ).astype("bool")
             _censoring[censored_idx] -= np.random.poisson(
-                lam=self.censoring_intensity, size=(censored_idx.sum(),)
-                ).astype("uint64")
-            X_temp = self._censor_array_list(X_temp, _censoring)
-            y_temp = self._censor_array_list(y_temp, _censoring)
+                lam=self.censoring_scale, size=(censored_idx.sum(),)
+            ).astype("uint64")
+            _censored_features = self._censor_array_list(_censored_features,
+                                                         _censoring)
+            _outcomes = self._censor_array_list(_outcomes, _censoring)
 
-        return self._filter_non_positive_samples(X_temp, y_temp,
-                                                 _censoring)
+            _features, _censored_features, _outcomes, censoring, _ = \
+                self._filter_non_positive_samples(_features, _censored_features,
+                                                  _outcomes, _censoring)
 
-    def _simulate_sccs_features(self, n_samples):
-        """Simulates features, either `infinite` or `short` exposures."""
-        if self.exposure_type == "infinite":
-            sim = self._sim_infinite_exposures
-        elif self.exposure_type == "short":
-            sim = self._sim_short_exposures
+        return _features, _censored_features, _outcomes, _censoring, _n_samples
 
-        return [sim() for _ in range(n_samples)]
+    def simulate_features(self, n_samples):
+        """Simulates features, either `single_exposure` or
+        `multiple_exposures` exposures.
+        """
+        if self.exposure_type == "single_exposure":
+            features, n_samples = self._sim_single_exposure_exposures()
+        elif self.exposure_type == "multiple_exposures":
+            sim = self._sim_multiple_exposures_exposures
+            features = [sim() for _ in range(n_samples)]
+        return features, n_samples
 
-    def _sim_short_exposures(self):
-        features = np.random.randint(2,
-                                     size=(self.n_intervals, self.n_features),
-                                     ).astype("float64")
+    # We just keep it for the tests now
+    # TODO later: need to be improved with Hawkes
+    def _sim_multiple_exposures_exposures(self):
+        features = np.zeros((self.n_intervals, self.n_features))
+        while features.sum() == 0:
+            # Make sure we do not generate empty feature matrix
+            features = np.random.randint(2,
+                                         size=(
+                                             self.n_intervals, self.n_features),
+                                         ).astype("float64")
         if self.sparse:
             features = csr_matrix(features, dtype="float64")
         return features
 
-    def _sim_infinite_exposures(self):
+    def _sim_single_exposure_exposures(self):
         if not self.sparse:
-            raise ValueError("'infinite' exposures can only be simulated as \
-            sparse feature matrices")
-        # Select features for which there is exposure
-        if self.n_features > 1:
-            n_exposures = np.random.randint(1, self.n_features, 1)
-            cols = np.random.choice(np.arange(self.n_features, dtype="int64"),
-                                    n_exposures, replace=False)
-        else:
-            n_exposures = 1
-            cols = np.array([0])
-        # choose exposure start
-        rows = np.random.randint(self.n_intervals, size=n_exposures)
-        # build sparse matrix
-        data = np.ones_like(cols, dtype="float64")
-        exposures = csr_matrix((data, (rows, cols)),
-                               shape=(self.n_intervals, self.n_features),
-                               dtype="float64")
-        return exposures
+            raise ValueError("'single_exposure' exposures can only be simulated"
+                             " as sparse feature matrices")
 
-    def _simulate_outcomes(self, features, censoring):
-        features = LongitudinalFeaturesLagger(n_lags=self.n_lags).\
-            fit_transform(features, censoring)
+        if self.hawkes_exp_kernels is None:
+            np.random.seed(self.seed)
+            decays = .002 * np.ones((self.n_features, self.n_features))
+            baseline = 4 * np.random.random(self.n_features) / self.n_intervals
+            mult = np.random.random(self.n_features)
+            adjacency = mult * np.eye(self.n_features)
+
+            if self.n_correlations:
+                comb = list(permutations(range(self.n_features), 2))
+                if len(comb) > 1:
+                    idx = itemgetter(*np.random.choice(range(len(comb)),
+                                                       size=self.n_correlations,
+                                                       replace=False))
+                    comb = idx(comb)
+
+                for i, j in comb:
+                    adjacency[i, j] = np.random.random(1)
+
+            self._set('hawkes_exp_kernels', SimuHawkesExpKernels(
+                adjacency=adjacency, decays=decays, baseline=baseline,
+                verbose=False, seed=self.seed))
+
+        self.hawkes_exp_kernels.adjust_spectral_radius(
+            .1)  # TODO later: allow to change this parameter
+        hawkes = SimuHawkesMulti(self.hawkes_exp_kernels,
+                                 n_simulations=self.n_cases)
+
+        run_time = self.n_intervals
+        hawkes.end_time = [1 * run_time for _ in range(self.n_cases)]
+        dt = 1
+        self.hawkes_exp_kernels.track_intensity(dt)
+        hawkes.simulate()
+
+        self.hawkes_obj = hawkes
+        features = [[np.min(np.floor(f)) if len(f) > 0 else -1
+                     for f in patient_events]
+                    for patient_events in hawkes.timestamps]
+
+        features = [self.to_coo(feat, (run_time, self.n_features)) for feat in
+                    features]
+
+        # Make sure patients have at least one exposure?
+        exposures_filter = itemgetter(*[i for i, f in enumerate(features)
+                                        if f.sum() > 0])
+        features = exposures_filter(features)
+        n_samples = len(features)
+
+        return features, n_samples
+
+    def simulate_outcomes(self, features):
+        features, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags). \
+            fit_transform(features)
 
         if self.distribution == "poisson":
-            y = self._simulate_outcome_from_poisson(features, self.coeffs,
-                                                    self.first_tick_only)
+            # TODO later: add self.max_n_events to allow for multiple outcomes
+            # In this case, the multinomial simulator should use this arg too
+            outcomes = self._simulate_poisson_outcomes(features, self.coeffs)
         else:
-            y = self._simulate_outcome_from_multi(features, self.coeffs,)
-        return y
+            outcomes = self._simulate_multinomial_outcomes(features,
+                                                           self.coeffs)
+        return outcomes
 
-    @staticmethod
-    def _simulate_outcome_from_multi(features, coeffs):
-        dot_products = [f.dot(coeffs) for f in features]
+    def _simulate_multinomial_outcomes(self, features, coeffs):
+        baseline = np.zeros(self.n_intervals)
+        if self.time_drift is not None:
+            baseline = self.time_drift(np.arange(self.n_intervals))
+        dot_products = [baseline + feat.dot(coeffs) for feat in features]
 
         def sim(dot_prod):
             dot_prod -= dot_prod.max()
-            probabilities = np.exp(dot_prod) / \
-                            np.sum(np.exp(dot_prod))
-            y = np.random.multinomial(1, probabilities)
-            return y.astype("int32")
+            probabilities = np.exp(dot_prod) / np.sum(np.exp(dot_prod))
+            outcomes = np.random.multinomial(1, probabilities)
+            return outcomes.astype("int32")
 
         return [sim(dot_product) for dot_product in dot_products]
 
-    @staticmethod
-    def _simulate_outcome_from_poisson(features, coeffs, first_tick_only=True):
-        dot_products = [feat.dot(coeffs) for feat in features]
+    def _simulate_poisson_outcomes(self, features, coeffs,
+                                   first_tick_only=True):
+        baseline = np.zeros(self.n_intervals)
+        if self.time_drift is not None:
+            baseline = self.time_drift(np.arange(self.n_intervals))
+        dot_products = [baseline + feat.dot(coeffs) for feat in features]
 
         def sim(dot_prod):
             dot_prod -= dot_prod.max()
-
             intensities = np.exp(dot_prod)
             ticks = np.random.poisson(lam=intensities)
             if first_tick_only:
@@ -317,28 +398,28 @@ class SimuSCCS(Simu):
     def _censor_array_list(array_list, censoring):
         """Apply censoring to a list of array-like objects. Works for 1-D or 2-D
         arrays, as long as the first axis represents the time.
-        
+
         Parameters
         ----------
         array_list : list of numpy.ndarray or list of scipy.sparse.csr_matrix,
-            list of length n_samples, each element of the list of 
+            list of length n_cases, each element of the list of
             shape=(n_intervals, n_features) or shape=(n_intervals,)
             The list of features matrices.
-            
-        censoring : `numpy.ndarray`, shape=(n_samples, 1), dtype="uint64"
-            The censoring data. This array should contain integers in 
+
+        censoring : `numpy.ndarray`, shape=(n_cases, 1), dtype="uint64"
+            The censoring data. This array should contain integers in
             [1, n_intervals]. If the value i is equal to n_intervals, then there
-            is no censoring for sample i. If censoring = c < n_intervals, then 
-            the observation of sample i is stopped at interval c, that is, the 
-            row c - 1 of the correponding matrix. The last n_intervals - c rows
+            is no censoring for sample i. If censoring = c < n_intervals, then
+            the observation of sample i is stopped at interval c, that is, the
+            row c - 1 of the corresponding matrix. The last n_intervals - c rows
             are then set to 0.
 
         Returns
         -------
         output : `[numpy.ndarrays]`  or `[csr_matrices]`, shape=(n_intervals, n_features)
             The list of censored features matrices.
-        
         """
+
         def censor(array, censoring_idx):
             if sps.issparse(array):
                 array = array.tolil()
@@ -351,17 +432,18 @@ class SimuSCCS(Simu):
         return [censor(l, censoring[i]) for i, l in enumerate(array_list)]
 
     @staticmethod
-    def _filter_non_positive_samples(features, labels, censoring):
+    def _filter_non_positive_samples(features, features_censored, labels,
+                                     censoring):
         """Filter out samples which don't tick in the observation window.
-        
+
         Parameters
         ----------
         features : list of numpy.ndarray or list of scipy.sparse.csr_matrix,
-            list of length n_samples, each element of the list of 
+            list of length n_cases, each element of the list of
             shape=(n_intervals, n_features)
             The list of features matrices.
-            
-        labels : list of numpy.ndarray of length n_samples,
+
+        labels : list of numpy.ndarray of length n_cases,
             shape=(n_intervals,)
             The list of labels matrices.
         """
@@ -373,9 +455,21 @@ class SimuSCCS(Simu):
              batch. Try to increase batch_size.")
         pos_samples_filter = itemgetter(*positive_sample_idx)
         return list(pos_samples_filter(features)),\
-            list(pos_samples_filter(labels)),\
-            censoring[positive_sample_idx],\
-            np.array(positive_sample_idx, dtype="uint64")
+               list(pos_samples_filter(features_censored)),\
+               list(pos_samples_filter(labels)),\
+               censoring[positive_sample_idx],\
+               np.array(positive_sample_idx, dtype="uint64")
+
+    @staticmethod
+    def to_coo(feat, shape):
+        feat = np.array(feat)
+        cols = np.where(feat >= 0)[0]
+        rows = np.array(feat[feat >= 0])
+        if len(cols) == 0:
+            cols = np.random.randint(0, shape[1], 1)
+            rows = np.random.randint(0, shape[0], 1)
+        data = np.ones_like(cols)
+        return csr_matrix((data, (rows, cols)), shape=shape, dtype="float64")
 
     @property
     def exposure_type(self):
@@ -383,8 +477,9 @@ class SimuSCCS(Simu):
 
     @exposure_type.setter
     def exposure_type(self, value):
-        if value not in ["infinite", "short"]:
-            raise ValueError("exposure_type can be only 'infinite' or 'short'.")
+        if value not in ["single_exposure", "multiple_exposures"]:
+            raise ValueError("exposure_type can be only 'single_exposure' or "
+                             "'multiple_exposures'.")
         self._set("_exposure_type", value)
 
     @property
@@ -394,8 +489,8 @@ class SimuSCCS(Simu):
     @distribution.setter
     def distribution(self, value):
         if value not in ["multinomial", "poisson"]:
-            raise ValueError("distribution can be only 'multinomial' or\
-             'poisson'.")
+            raise ValueError("distribution can be only 'multinomial' or "
+                             "'poisson'.")
         self._set("_distribution", value)
 
     @property
@@ -405,18 +500,18 @@ class SimuSCCS(Simu):
     @censoring_prob.setter
     def censoring_prob(self, value):
         if value < 0 or value > 1:
-            raise ValueError("value should be in [0, 1].")
+            raise ValueError("censoring_prob value should be in [0, 1].")
         self._set("_censoring_prob", value)
 
     @property
-    def censoring_intensity(self):
-        return self._censoring_intensity
+    def censoring_scale(self):
+        return self._censoring_scale
 
-    @censoring_intensity.setter
-    def censoring_intensity(self, value):
+    @censoring_scale.setter
+    def censoring_scale(self, value):
         if value < 0:
-            raise ValueError("censoring_intensity should be greater than 0.")
-        self._set("_censoring_intensity", value)
+            raise ValueError("censoring_scale should be greater than 0.")
+        self._set("_censoring_scale", value)
 
     @property
     def coeffs(self):
@@ -425,7 +520,7 @@ class SimuSCCS(Simu):
     @coeffs.setter
     def coeffs(self, value):
         if value is not None and \
-                        value.shape != (self.n_features * (self.n_lags + 1),):
+                value.shape != (int(self.n_lags.sum() + self.n_features),):
             raise ValueError("Coeffs should be of shape\
              (n_features * (n_lags + 1),)")
         self._set("_coeffs", value)
@@ -437,9 +532,95 @@ class SimuSCCS(Simu):
     @batch_size.setter
     def batch_size(self, value):
         if value is None and self.distribution == "multinomial":
-            self._set("_batch_size", self.n_samples)
+            self._set("_batch_size", self.n_cases)
         elif value is None:
-            self._set("_batch_size", int(min(2000, self.n_samples)))
+            self._set("_batch_size", int(min(2000, self.n_cases)))
         else:
             self._set("_batch_size", int(value))
         self._set("_batch_size", max(100, self.batch_size))
+
+
+class CustomEffects:
+    def __init__(self, n_intervals):
+        """Class provinding flexible relative incidence curves to be used as
+        coefficients in the `SimuSCCS` class.
+
+        Parameters
+        ----------
+        n_intervals : `int`
+            Number of time intervals used to generate features and outcomes.
+        """
+        self.n_intervals = n_intervals
+        self._curves_type_dict = {
+            1: (5, 1),
+            2: (2, 2),
+            3: (.5, .5),
+            4: (2, 5),
+            5: (1, 3)
+        }
+
+    def constant_effect(self, amplitude, cut=0):
+        """Returns coefficients corresponding to a constant relative incidence
+        of value equal to `amplitude`. If `cut` is greater than 0, the relative
+        incidence will be null on [`cut`, `n_intervals`]
+        """
+        risk_curve = np.ones(self.n_intervals) * amplitude
+        if cut > 0:
+            risk_curve[cut:] = 1
+        return risk_curve
+
+    def bell_shaped_effect(self, amplitude, width, lag=0, cut=0):
+        """Returns coefficients corresponding to a bell shaped relative
+        incidence of max value equal to `amplitude`. If `cut` is greater than 0,
+        the relative incidence will be null on [`cut`, `n_intervals`]. The
+        effect starts at `lag` interval, and lasts `width` intervals.
+        """
+        self._check_params(lag, width, amplitude, cut)
+        if width % 2 == 0:
+            width += 1
+        effect = norm(0, width / 5).pdf(np.arange(width) - int(width / 2))
+        return self._create_risk_curve(effect, amplitude, cut, width, lag)
+
+    def increasing_effect(self, amplitude, lag=0, cut=0, curvature_type=1):
+        """Returns coefficients corresponding to an increasing relative
+        incidence of max value equal to `amplitude`. If `cut` is greater than 0,
+        the relative incidence will be null on [`cut`, `n_intervals`]. The
+        effect starts at `lag` interval, and lasts `width` intervals.
+        The parameter `curvature_type` controls the shape of the relative
+        incidence curve, it can take values in {1, 2, 3, 4, 5}.
+        """
+        width = self.n_intervals
+        self._check_params(lag, width, amplitude, cut)
+        if curvature_type not in np.arange(5) + 1:
+            raise ValueError('curvature type should be in {1, 2, 3, 4, 5}')
+        a, b = self._curves_type_dict[curvature_type]
+        effect = beta(a, b).cdf(np.arange(width) / width)
+        return self._create_risk_curve(effect, amplitude, cut, width, lag)
+
+    def _check_params(self, lag, width, amplitude, cut):
+        if cut is not None and cut >= width:
+            raise ValueError('cut should be < width')
+        if lag > self.n_intervals:
+            raise ValueError('n_intervals should be > lag')
+        if amplitude <= 0:
+            raise ValueError('amplitude should be > 0')
+
+    def _create_risk_curve(self, effect, amplitude, cut, width, lag):
+        if cut:
+            effect = effect[:int(width - cut)]
+        end_effect = int(lag + width - cut)
+        if end_effect > self.n_intervals:
+            end_effect = self.n_intervals
+        effect = effect[:end_effect - lag]
+
+        M = effect.max()
+        m = effect.min()
+        effect = (effect - m) / (M - m)
+        effect *= (amplitude - 1)
+        risk_curve = np.ones(self.n_intervals)
+        risk_curve[lag:end_effect] += effect
+        return risk_curve
+
+    @staticmethod
+    def negative_effect(positive_effect):
+        return np.exp(-np.log(positive_effect))

--- a/tick/survival/tests/convolutional_sccs_test.py
+++ b/tick/survival/tests/convolutional_sccs_test.py
@@ -1,0 +1,142 @@
+import unittest
+import numpy as np
+from tick.survival import SimuSCCS, ConvSCCS
+from scipy.sparse import csr_matrix
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.n_lags = np.repeat(1, 2).astype('uint64')
+        self.seed = 42
+        self.coeffs = np.log(np.array([2.1, 2.5,
+                                       .8, .5]))
+        self.n_features = len(self.n_lags)
+        self.n_correlations = 2
+        # Create data
+        sim = SimuSCCS(n_cases=500, n_intervals=10, n_features=self.n_features,
+                       n_lags=self.n_lags, verbose=False, seed=self.seed,
+                       coeffs=self.coeffs, n_correlations=self.n_correlations)
+        _, self.features, self.labels, self.censoring, self.coeffs =\
+            sim.simulate()
+
+    def test_LearnerSCCS_coefficient_groups(self):
+        n_lags = np.array([4, 0, 3, 4], dtype='uint64')
+        n_features = len(n_lags)
+        n_coeffs = (n_lags+1).sum()
+        coeffs = np.ones((n_coeffs,))
+        # 1st feature
+        coeffs[1:3] = 2
+        # 2nd feature
+        coeffs[5] = 1
+        # 3rd feature
+        coeffs[6:8] = 0
+        # 4th feature
+        coeffs[10:] = np.array([1, 2, 3, 4, 4])
+        expected_equality_groups = [(1, 3), (3, 5),
+                                    (6, 8), (8, 10),
+                                    (13, 15)
+                                    ]
+        lrn = ConvSCCS(n_lags=n_lags, penalized_features=np.arange(4))
+        lrn._set("n_features", n_features)
+        equality_groups = lrn._detect_support(coeffs)
+        self.assertEqual(expected_equality_groups, equality_groups)
+
+    def test_LearnerSCCS_preprocess(self):
+        features = [np.array([[0, 1, 0],
+                              [0, 0, 0],
+                              [0, 1, 1]], dtype="float64"),
+                    np.array([[1, 0, 1],
+                              [0, 0, 1],
+                              [1, 0, 0]], dtype="float64"),
+                    np.array([[1, 1, 1],
+                              [0, 0, 1],
+                              [1, 1, 0]], dtype="float64")
+                    ]
+        sparse_features = [csr_matrix(f, shape=(3, 3)) for f in features]
+        labels = [np.array([0, 0, 1], dtype="uint64"),
+                  np.array([0, 1, 0], dtype="uint64"),
+                  np.array([0, 0, 0], dtype="uint64")]
+        censoring = np.array([2, 3, 3], dtype="uint64")
+        n_lags = np.array([1, 1, 0], dtype="uint64")
+
+        expected_features = [np.array([[0, 0, 1, 0, 0],
+                                       [0, 0, 0, 1, 0],
+                                       [0, 0, 0, 0, 0]]),
+                             np.array([[1, 0, 0, 0, 1],
+                                       [0, 1, 0, 0, 1],
+                                       [1, 0, 0, 0, 0]])
+                             ]
+        expected_labels = [np.array([0, 0, 1], dtype="uint64"),
+                           np.array([0, 1, 0], dtype="uint64"),]
+        expected_censoring  = np.array([2, 3], dtype="uint64")
+
+        lrn = ConvSCCS(n_lags=n_lags, penalized_features=[])
+        X, y, c = lrn._prefit(sparse_features, labels, censoring)
+        [np.testing.assert_array_equal(f.toarray(), expected_features[i])
+         for i, f in enumerate(X)]
+        [np.testing.assert_array_equal(l, expected_labels[i])
+         for i, l in enumerate(y)]
+        np.testing.assert_array_equal(c, expected_censoring)
+
+    def test_LearnerSCCS_fit(self):
+        seed = 42
+        n_lags = np.repeat(2, 2).astype('uint64')
+        sim = SimuSCCS(n_cases=800, n_intervals=10, n_features=2,
+                       n_lags=n_lags, verbose=False, seed=seed,
+                       exposure_type='multiple_exposures')
+        features, _, labels, censoring, coeffs = sim.simulate()
+        lrn = ConvSCCS(n_lags=n_lags, penalized_features=[],
+                       tol=0, max_iter=10, random_state=seed)
+        estimated_coeffs, _ = lrn.fit(features, labels, censoring)
+        np.testing.assert_almost_equal(estimated_coeffs, coeffs, decimal=1)
+
+    def test_LearnerSCCS_bootstrap_CI(self):
+        lrn = ConvSCCS(n_lags=self.n_lags, penalized_features=[])
+        coeffs, _ = lrn.fit(self.features, self.labels, self.censoring)
+        p_features, p_labels, p_censoring = lrn._preprocess_data(self.features,
+                                                                 self.labels,
+                                                                 self.censoring)
+        bootstrap_ci = lrn._bootstrap(p_features, p_labels, p_censoring,
+                                      coeffs, 5, .90)
+        self.assertTrue(np.all(bootstrap_ci.lower_bound <= coeffs),
+                        "lower bound of the confidence interval\
+                               should be <= coeffs")
+        self.assertTrue(np.all(coeffs <= bootstrap_ci.upper_bound),
+                        "upper bound of the confidence interval\
+                               should be >= coeffs")
+        # Same with 0 lags
+        n_lags = np.zeros_like(self.n_lags, dtype='uint64')
+        lrn = ConvSCCS(n_lags=n_lags, penalized_features=[])
+        coeffs, _ = lrn.fit(self.features, self.labels, self.censoring)
+        p_features, p_labels, p_censoring = lrn._preprocess_data(self.features,
+                                                                 self.labels,
+                                                                 self.censoring)
+        bootstrap_ci = lrn._bootstrap(p_features, p_labels, p_censoring,
+                                      coeffs, 5, .90)
+        self.assertTrue(np.all(bootstrap_ci.lower_bound <= coeffs),
+                        "lower bound of the confidence interval\
+                               should be <= coeffs")
+        self.assertTrue(np.all(coeffs <= bootstrap_ci.upper_bound),
+                        "upper bound of the confidence interval\
+                               should be >= coeffs")
+
+    def test_LearnerSCCS_score(self):
+        lrn = ConvSCCS(n_lags=self.n_lags, penalized_features=[],
+                       random_state=self.seed)
+        lrn.fit(self.features, self.labels, self.censoring)
+        self.assertEqual(lrn.score(),
+                         lrn.score(self.features, self.labels, self.censoring))
+
+    def test_LearnerSCCS_fit_KFold_CV(self):
+        lrn = ConvSCCS(n_lags=self.n_lags,
+                       penalized_features=np.arange(self.n_features),
+                       random_state=self.seed, strength_tv=1e-1,
+                       strength_group_l1=1e-1)
+        lrn.fit(self.features, self.labels, self.censoring)
+        score = lrn.score()
+        tv_range = (-5, -1)
+        groupl1_range = (-5, -1)
+        lrn.fit_kfold_cv(self.features, self.labels, self.censoring,
+                         strength_tv_range=tv_range,
+                         strength_group_l1_range=groupl1_range, n_cv_iter=4)
+        self.assertTrue(lrn.score() <= score)

--- a/tick/survival/tests/model_sccs_test.py
+++ b/tick/survival/tests/model_sccs_test.py
@@ -1,16 +1,14 @@
 # License: BSD 3 clause
 
 import unittest
-
 import numpy as np
-from scipy.linalg import norm
 from scipy.optimize import check_grad, fmin_bfgs
+from scipy.linalg import norm
 from scipy.sparse import csr_matrix
-
 from tick.survival import SimuSCCS, ModelSCCS
 from tick.preprocessing import LongitudinalFeaturesLagger
-from tick.prox import ProxZero
 from tick.solver import SVRG
+from tick.prox import ProxZero
 
 
 class ModelSCCSTest(unittest.TestCase):
@@ -20,20 +18,22 @@ class ModelSCCSTest(unittest.TestCase):
                             [0, 1]], dtype="float64"),
                   np.array([[1, 1],
                             [1, 0]], dtype="float64")
-                  ]
+                 ]
         self.y = [np.array([1, 0], dtype="int32"),
                   np.array([0, 1], dtype="int32")
-                  ]
+                 ]
+
+        self.n_lags = np.array([1, 1], dtype="uint64")
 
     def test_loss(self):
         """Test longitudinal multinomial model loss."""
-        X = LongitudinalFeaturesLagger(n_lags=1) \
+        X, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags)\
             .fit_transform(self.X)
-        model = ModelSCCS(n_intervals=2, n_lags=1) \
+        model = ModelSCCS(n_intervals=2, n_lags=self.n_lags)\
             .fit(X, self.y)
         loss = model.loss(coeffs=np.array([0.0, 0.0, 1.0, 0.0]))
-        expected_loss = - np.log((np.e / (2 * np.e) * 1 / (1 + np.e))) / 2
-        self.assertAlmostEquals(loss, expected_loss)
+        expected_loss = - np.log((np.e / (2*np.e) * 1 / (1 + np.e))) / 2
+        self.assertAlmostEqual(loss, expected_loss)
 
     def test_grad(self):
         """Test longitudinal multinomial model gradient value."""
@@ -42,12 +42,12 @@ class ModelSCCSTest(unittest.TestCase):
              np.array([[1, 0.],
                        [0, 1]])
              ]
-        X = LongitudinalFeaturesLagger(n_lags=1) \
+        X, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags) \
             .fit_transform(X)
-        model = ModelSCCS(n_intervals=2, n_lags=1) \
+        model = ModelSCCS(n_intervals=2, n_lags=self.n_lags) \
             .fit(X, self.y)
         grad = model.grad(coeffs=np.array([0.0, 0.0, 1.0, 0.0]))
-        expected_grad = - np.array([-1 / 2 - 1 / (1 + np.e),
+        expected_grad = - np.array([-1/2 - 1 / (1 + np.e),
                                     1 - np.e / (1 + np.e),
                                     1 - np.e / (1 + np.e),
                                     0]) / 2
@@ -55,18 +55,17 @@ class ModelSCCSTest(unittest.TestCase):
 
     def test_grad_loss_consistency(self):
         """Test longitudinal multinomial model gradient properties."""
-        n_intervals = 16
-        n_lags = 4
-        sim = SimuSCCS(500, n_intervals, 3, n_lags, None,
-                       True, "infinite", seed=42, verbose=False)
-        X, y, censoring, coeffs = sim.simulate()
-        X = LongitudinalFeaturesLagger(n_lags=n_lags) \
+        n_lags = np.repeat(9, 3).astype(dtype="uint64")
+        sim = SimuSCCS(500, 36, 3, n_lags, None, "single_exposure", seed=42,
+                       verbose=False)
+        _, X, y, censoring, coeffs = sim.simulate()
+        X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X, censoring)
-        model = ModelSCCS(n_intervals=n_intervals, n_lags=n_lags) \
+        model = ModelSCCS(n_intervals=36, n_lags=n_lags)\
             .fit(X, y, censoring)
         self._test_grad(model, coeffs)
         X_sparse = [csr_matrix(x) for x in X]
-        model = ModelSCCS(n_intervals=n_intervals, n_lags=n_lags) \
+        model = ModelSCCS(n_intervals=36, n_lags=n_lags)\
             .fit(X_sparse, y, censoring)
         self._test_grad(model, coeffs)
 
@@ -82,42 +81,43 @@ class ModelSCCSTest(unittest.TestCase):
         y = [np.array([0, 1, 0], dtype="int32"),
              np.array([0, 1, 0], dtype="int32")
              ]
-        X = LongitudinalFeaturesLagger(n_lags=1) \
+        n_lags = np.repeat(1, 3).astype(dtype="uint64")
+        X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X)
-        model = ModelSCCS(n_intervals=3, n_lags=1).fit(
+        model = ModelSCCS(n_intervals=3, n_lags=n_lags).fit(
             X, y)
         lip_constant = model.get_lip_max()
         expected_lip_constant = .5
-        self.assertEquals(lip_constant, expected_lip_constant)
+        self.assertEqual(lip_constant, expected_lip_constant)
 
     def test_convergence_with_lags(self):
         """Test longitudinal multinomial model convergence."""
         n_intervals = 10
-        n_lags = 3
-        n_samples = 1500
-        n_features = 3
+        n_samples = 800
+        n_features = 2
+        n_lags = np.repeat(2, n_features).astype(dtype="uint64")
         sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags, None,
-                       True, "short", seed=42, verbose=False)
-        X, y, censoring, coeffs = sim.simulate()
-        X = LongitudinalFeaturesLagger(n_lags=n_lags) \
+                       "multiple_exposures", seed=42)
+        _, X, y, censoring, coeffs = sim.simulate()
+        X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X, censoring)
         model = ModelSCCS(n_intervals=n_intervals,
                           n_lags=n_lags).fit(X, y, censoring)
         solver = SVRG(max_iter=15, verbose=False)
         solver.set_model(model).set_prox(ProxZero())
-        coeffs_svrg = solver.solve(step=1 / model.get_lip_max())
+        coeffs_svrg = solver.solve(step=1/model.get_lip_max())
         np.testing.assert_almost_equal(coeffs, coeffs_svrg, decimal=1)
 
     def test_convergence_without_lags(self):
         """Test longitudinal multinomial model convergence."""
         n_intervals = 10
-        n_lags = 0
-        n_samples = 1500
-        n_features = 3
-        sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags, None, True,
-                       "short", seed=42, verbose=False)
-        X, y, censoring, coeffs = sim.simulate()
-        X = LongitudinalFeaturesLagger(n_lags=n_lags) \
+        n_samples = 600
+        n_features = 2
+        n_lags = np.repeat(0, n_features).astype(dtype="uint64")
+        sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags, None,
+                       "multiple_exposures", seed=42, verbose=False)
+        _, X, y, censoring, coeffs = sim.simulate()
+        X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X, censoring)
         model = ModelSCCS(n_intervals=n_intervals,
                           n_lags=n_lags).fit(X, y, censoring)
@@ -129,19 +129,19 @@ class ModelSCCSTest(unittest.TestCase):
     def _test_grad(self, model, coeffs,
                    delta_check_grad=1e-5,
                    delta_model_grad=1e-4):
-        """Test that gradient is consistent with loss and that minimum is
-        achievable with a small gradient
-        """
-        self.assertAlmostEqual(check_grad(model.loss,
-                                          model.grad,
-                                          coeffs),
-                               0.,
-                               delta=delta_check_grad)
-        # Check that minimum iss achievable with a small gradient
-        coeffs_min = fmin_bfgs(model.loss, coeffs,
-                               fprime=model.grad, disp=False)
-        self.assertAlmostEqual(norm(model.grad(coeffs_min)),
-                               .0, delta=delta_model_grad)
+            """Test that gradient is consistent with loss and that minimum is
+            achievable with a small gradient
+            """
+            self.assertAlmostEqual(check_grad(model.loss,
+                                              model.grad,
+                                              coeffs),
+                                   0.,
+                                   delta=delta_check_grad)
+            # Check that minimum iss achievable with a small gradient
+            coeffs_min = fmin_bfgs(model.loss, coeffs,
+                                   fprime=model.grad, disp=False)
+            self.assertAlmostEqual(norm(model.grad(coeffs_min)),
+                                   .0, delta=delta_model_grad)
 
 
 if __name__ == '__main__':

--- a/tick/survival/tests/model_sccs_test.py
+++ b/tick/survival/tests/model_sccs_test.py
@@ -59,6 +59,7 @@ class ModelSCCSTest(unittest.TestCase):
         sim = SimuSCCS(500, 36, 3, n_lags, None, "single_exposure", seed=42,
                        verbose=False)
         _, X, y, censoring, coeffs = sim.simulate()
+        coeffs =np.hstack(coeffs)
         X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X, censoring)
         model = ModelSCCS(n_intervals=36, n_lags=n_lags)\
@@ -99,6 +100,7 @@ class ModelSCCSTest(unittest.TestCase):
         sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags, None,
                        "multiple_exposures", seed=42)
         _, X, y, censoring, coeffs = sim.simulate()
+        coeffs = np.hstack(coeffs)
         X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X, censoring)
         model = ModelSCCS(n_intervals=n_intervals,
@@ -117,6 +119,7 @@ class ModelSCCSTest(unittest.TestCase):
         sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags, None,
                        "multiple_exposures", seed=42, verbose=False)
         _, X, y, censoring, coeffs = sim.simulate()
+        coeffs = np.hstack(coeffs)
         X, _, _ = LongitudinalFeaturesLagger(n_lags=n_lags) \
             .fit_transform(X, censoring)
         model = ModelSCCS(n_intervals=n_intervals,

--- a/tick/survival/tests/simu_sccs_test.py
+++ b/tick/survival/tests/simu_sccs_test.py
@@ -9,8 +9,8 @@ from tick.survival import SimuSCCS
 class Test(unittest.TestCase):
 
     def test_censoring(self):
-        array_list = [np.ones((2, 3)) for i in range(3)]
-        expected = [np.zeros((2, 3)) for i in range(3)]
+        array_list = [np.ones((2, 3)) for _ in range(3)]
+        expected = [np.zeros((2, 3)) for _ in range(3)]
         for i in range(1, 3):
             expected[i][:i] += 1
         censoring = np.arange(3)
@@ -22,59 +22,62 @@ class Test(unittest.TestCase):
 
     def test_filter_non_positive_samples(self):
         features = [np.ones((2, 3)) * i for i in range(10)]
-        labels = [np.zeros((2, 1)) for i in range(10)]
+        labels = [np.zeros((2, 1)) for _ in range(10)]
         censoring = np.full((10, 1), 2)
 
         expected_idx = np.sort(np.random.choice(np.arange(10), 5, False))
         for i in expected_idx:
             labels[i][i % 2] = 1
         expect_feat = [features[i] for i in expected_idx]
+        expect_feat_c = expect_feat
         expect_lab = [labels[i] for i in expected_idx]
         expect_cens = censoring[expected_idx]
 
-        out_feat, out_lab, out_cens, out_idx = SimuSCCS\
-            ._filter_non_positive_samples(features, labels, censoring)
+        out_feat, out_feat_c, out_lab, out_cens, out_idx = SimuSCCS\
+            ._filter_non_positive_samples(features, features, labels, censoring)
 
         np.testing.assert_array_equal(expect_cens, out_cens)
         for i in range(len(expect_cens)):
             np.testing.assert_array_equal(expect_feat[i], out_feat[i])
+            np.testing.assert_array_equal(expect_feat_c[i], out_feat_c[i])
             np.testing.assert_array_equal(expect_lab[i], out_lab[i])
             self.assertGreater(expect_lab[i].sum(), 0)
 
+    def test_simulated_features(self):
+        sim = SimuSCCS(100, 10, 3, 2, None, 'multiple_exposures', verbose=False)
+        feat, n_samples = sim.simulate_features(100)
+        self.assertEqual(100, len(feat))
+        print(np.sum([1 for f in feat if f.sum() <= 0]))
+
     def test_simulation(self):
-        def run_tests(n_samples, n_features, sparse, exposure_type,
-                      distribution, first_tick_only, censoring):
+        def run_tests(n_cases, n_features, sparse, exposure_type, distribution,
+                      time_drift):
             n_intervals = 5
-            n_lags = 2
-            sim = SimuSCCS(n_samples, n_intervals, n_features, n_lags, None,
-                           sparse, exposure_type, distribution, first_tick_only,
-                           censoring, seed=42, verbose=False)
-            X, y, c, coeffs = sim.simulate()
-            self.assertEqual(len(X), n_samples)
-            self.assertEqual(len(y), n_samples)
+            n_lags = np.repeat(2, n_features).astype('uint64')
+            sim = SimuSCCS(n_cases, n_intervals, n_features, n_lags, time_drift,
+                           exposure_type, distribution, sparse, verbose=False)
+            X, X_c, y, c, coeffs = sim.simulate()
+            self.assertEqual(len(X), n_cases)
+            self.assertEqual(len(y), n_cases)
             self.assertEqual(X[0].shape, (n_intervals, n_features))
             self.assertEqual(y[0].shape, (n_intervals,))
-            self.assertEqual(c.shape, (n_samples,))
-            self.assertEqual(coeffs.shape, (n_features * (n_lags + 1),))
+            self.assertEqual(c.shape, (n_cases,))
+            self.assertEqual(coeffs.shape, ((n_lags + 1).sum(),))
+            self.assertEqual(np.sum([1 for f in X if f.sum() <= 0]), 0)
+            self.assertEqual(np.sum([1 for f in X_c if f.sum() <= 0]), 0)
 
-        n_samples = [1, 100]
         n_features = [1, 3]
-        exposure_type = ["infinite", "short"]
+        exposure_type = ["single_exposure", "multiple_exposures"]
         distribution = ["multinomial", "poisson"]
-        first_tick_only = [True, False]
-        censoring = [True, False]
         sparse = [True, False]
-        for n, n_feat, e, d, f, c in itertools.product(n_samples,
-                                                       n_features,
-                                                       exposure_type,
-                                                       distribution,
-                                                       first_tick_only,
-                                                       censoring):
-            if e == "short":
+        time_drift = [None, lambda x: np.log(np.sin(x * 2) + 5)]
+        for n_feat, e, d, td in itertools.product(n_features, exposure_type,
+                                                  distribution, time_drift):
+            if e == "multiple_exposures":
                 for s in sparse:
-                    run_tests(n, n_feat, s, e, d, f, c)
+                    run_tests(10, n_feat, s, e, d, td)
             else:
-                run_tests(n, n_feat, True, e, d, f, c)
+                run_tests(10, n_feat, True, e, d, td)
 
 
 if __name__ == '__main__':

--- a/tick/survival/tests/simu_sccs_test.py
+++ b/tick/survival/tests/simu_sccs_test.py
@@ -44,7 +44,10 @@ class Test(unittest.TestCase):
             self.assertGreater(expect_lab[i].sum(), 0)
 
     def test_simulated_features(self):
-        sim = SimuSCCS(100, 10, 3, 2, None, 'multiple_exposures', verbose=False)
+        n_features = 3
+        n_lags = np.repeat(2, n_features)
+        sim = SimuSCCS(100, 10, n_features, n_lags, None,
+                       'multiple_exposures', verbose=False)
         feat, n_samples = sim.simulate_features(100)
         self.assertEqual(100, len(feat))
         print(np.sum([1 for f in feat if f.sum() <= 0]))
@@ -62,7 +65,8 @@ class Test(unittest.TestCase):
             self.assertEqual(X[0].shape, (n_intervals, n_features))
             self.assertEqual(y[0].shape, (n_intervals,))
             self.assertEqual(c.shape, (n_cases,))
-            self.assertEqual(coeffs.shape, ((n_lags + 1).sum(),))
+            [self.assertEqual(co.shape, (int(n_lags[i]+1),))
+             for i, co in enumerate(coeffs)]
             self.assertEqual(np.sum([1 for f in X if f.sum() <= 0]), 0)
             self.assertEqual(np.sum([1 for f in X_c if f.sum() <= 0]), 0)
 


### PR DESCRIPTION
Add ConvSCCS model + refactoring of SCCS-related stuff (preprocessing, simulations, etc.) according to the paper

Feature products are not shipped as a learner option for now, but it can be used independently.

Most objects are not picklable for now, this should be fixed in another task to allow parallel CV and bootstrap.