### PR TITLE
Make least sq weights computation faster

### DIFF
--- a/lib/cpp-test/benchmark/hawkes_leastsq_weights.cpp
+++ b/lib/cpp-test/benchmark/hawkes_leastsq_weights.cpp
@@ -11,7 +11,7 @@ int main(int nargs, char **args) {
 
   const ulong num_iterations = 100;
   const ulong num_events_per_node = 30;
-  const ulong num_nodes = 20;
+  const ulong num_nodes = 40;
   const ulong num_decays = 10;
   const ulong num_baselines = 1;
 


### PR DESCRIPTION
This was work done at intel workshop. Almost 4 times faster

Benchmark before optimization
![results_before_40](https://user-images.githubusercontent.com/1908833/35967042-f38e2890-0cbf-11e8-9581-0ccd39a0f164.png)

Benchmark after optimization
![results_after_40](https://user-images.githubusercontent.com/1908833/35967064-0190904a-0cc0-11e8-9e43-822531d05ff3.png)
