### PR TITLE
Compute metrics (such a objective) only if they will be recorded.

### DIFF
--- a/tick/hawkes/inference/hawkes_basis_kernels.py
+++ b/tick/hawkes/inference/hawkes_basis_kernels.py
@@ -254,31 +254,33 @@ class HawkesBasisKernels(LearnerHawkesNoParam):
                                      self.n_nodes * self.n_basis)))
 
         for i in range(self.max_iter + 1):
-            prev_baseline = self.baseline.copy()
-            prev_amplitudes = self.amplitudes.copy()
-            prev_basis_kernels = self.basis_kernels.copy()
+            if self._should_record_iter(i):
+                prev_baseline = self.baseline.copy()
+                prev_amplitudes = self.amplitudes.copy()
+                prev_basis_kernels = self.basis_kernels.copy()
 
             rel_ode = self._learner.solve(self.baseline, self.basis_kernels,
                                           self._amplitudes_2d,
                                           self.ode_max_iter, self.ode_tol)
 
-            rel_baseline = relative_distance(self.baseline, prev_baseline)
-            rel_amplitudes = relative_distance(self.amplitudes,
-                                               prev_amplitudes)
-            rel_basis_kernels = relative_distance(self.basis_kernels,
-                                                  prev_basis_kernels)
+            if self._should_record_iter(i):
+                rel_baseline = relative_distance(self.baseline, prev_baseline)
+                rel_amplitudes = relative_distance(self.amplitudes,
+                                                   prev_amplitudes)
+                rel_basis_kernels = relative_distance(self.basis_kernels,
+                                                      prev_basis_kernels)
 
-            converged = max(rel_baseline, rel_amplitudes,
-                            rel_basis_kernels) <= self.tol
-            force_print = (i == self.max_iter) or converged
+                converged = max(rel_baseline, rel_amplitudes,
+                                rel_basis_kernels) <= self.tol
+                force_print = (i == self.max_iter) or converged
 
-            self._handle_history(i, rel_baseline=rel_baseline,
-                                 rel_amplitudes=rel_amplitudes,
-                                 rel_basis_kernels=rel_basis_kernels,
-                                 rel_ode=rel_ode, force=force_print)
+                self._handle_history(i, rel_baseline=rel_baseline,
+                                     rel_amplitudes=rel_amplitudes,
+                                     rel_basis_kernels=rel_basis_kernels,
+                                     rel_ode=rel_ode, force=force_print)
 
-            if converged:
-                break
+                if converged:
+                    break
 
     def get_kernel_supports(self):
         return np.zeros((self.n_nodes, self.n_nodes)) + self.kernel_support

--- a/tick/hawkes/inference/hawkes_em.py
+++ b/tick/hawkes/inference/hawkes_em.py
@@ -177,21 +177,23 @@ class HawkesEM(LearnerHawkesNoParam):
             self.baseline = baseline_start.copy()
 
         for i in range(self.max_iter + 1):
-            prev_baseline = self.baseline.copy()
-            prev_kernel = self.kernel.copy()
+            if self._should_record_iter(i):
+                prev_baseline = self.baseline.copy()
+                prev_kernel = self.kernel.copy()
 
             self._learner.solve(self.baseline, self._flat_kernels)
 
-            rel_baseline = relative_distance(self.baseline, prev_baseline)
-            rel_kernel = relative_distance(self.kernel, prev_kernel)
+            if self._should_record_iter(i):
+                rel_baseline = relative_distance(self.baseline, prev_baseline)
+                rel_kernel = relative_distance(self.kernel, prev_kernel)
 
-            converged = max(rel_baseline, rel_kernel) <= self.tol
-            force_print = (i == self.max_iter) or converged
-            self._handle_history(i, rel_baseline=rel_baseline,
-                                 rel_kernel=rel_kernel, force=force_print)
+                converged = max(rel_baseline, rel_kernel) <= self.tol
+                force_print = (i == self.max_iter) or converged
+                self._handle_history(i, rel_baseline=rel_baseline,
+                                     rel_kernel=rel_kernel, force=force_print)
 
-            if converged:
-                break
+                if converged:
+                    break
 
     def get_kernel_supports(self):
         """Computes kernel support. This makes our learner compliant with

--- a/tick/hawkes/inference/hawkes_sumgaussians.py
+++ b/tick/hawkes/inference/hawkes_sumgaussians.py
@@ -271,41 +271,45 @@ class HawkesSumGaussians(LearnerHawkesNoParam):
 
         max_relative_distance = 1e-1
         for i in range(self.max_iter + 1):
-            prev_baseline = self.baseline.copy()
-            prev_amplitudes = self.amplitudes.copy()
+            if self._should_record_iter(i):
+                prev_baseline = self.baseline.copy()
+                prev_amplitudes = self.amplitudes.copy()
 
-            inner_prev_baseline = self.baseline.copy()
-            inner_prev_amplitudes = self.amplitudes.copy()
+                inner_prev_baseline = self.baseline.copy()
+                inner_prev_amplitudes = self.amplitudes.copy()
+
             self._learner.solve(self.baseline, _amplitudes_2d)
-            inner_rel_baseline = relative_distance(self.baseline,
-                                                   inner_prev_baseline)
-            inner_rel_adjacency = relative_distance(self.amplitudes,
-                                                    inner_prev_amplitudes)
 
-            if self.em_tol is None:
-                inner_tol = max_relative_distance * 1e-2
-            else:
-                inner_tol = self.em_tol
+            if self._should_record_iter(i):
+                inner_rel_baseline = relative_distance(self.baseline,
+                                                       inner_prev_baseline)
+                inner_rel_adjacency = relative_distance(
+                    self.amplitudes, inner_prev_amplitudes)
 
-            if max(inner_rel_baseline, inner_rel_adjacency) < inner_tol:
-                break
+                if self.em_tol is None:
+                    inner_tol = max_relative_distance * 1e-2
+                else:
+                    inner_tol = self.em_tol
 
-            rel_baseline = relative_distance(self.baseline, prev_baseline)
-            rel_amplitudes = relative_distance(self.amplitudes,
-                                               prev_amplitudes)
+                if max(inner_rel_baseline, inner_rel_adjacency) < inner_tol:
+                    break
 
-            max_relative_distance = max(rel_baseline, rel_amplitudes)
-            # We perform at least 5 iterations as at start we sometimes reach a
-            # low tolerance if inner_tol is too low
-            converged = max_relative_distance <= self.tol and i > 5
-            force_print = (i == self.max_iter) or converged
+                rel_baseline = relative_distance(self.baseline, prev_baseline)
+                rel_amplitudes = relative_distance(self.amplitudes,
+                                                   prev_amplitudes)
 
-            self._handle_history(i, rel_baseline=rel_baseline,
-                                 rel_amplitudes=rel_amplitudes,
-                                 force=force_print)
+                max_relative_distance = max(rel_baseline, rel_amplitudes)
+                # We perform at least 5 iterations as at start we sometimes
+                # reach a low tolerance if inner_tol is too low
+                converged = max_relative_distance <= self.tol and i > 5
+                force_print = (i == self.max_iter) or converged
 
-            if converged:
-                break
+                self._handle_history(i, rel_baseline=rel_baseline,
+                                     rel_amplitudes=rel_amplitudes,
+                                     force=force_print)
+
+                if converged:
+                    break
 
     @property
     def C(self):

--- a/tick/hawkes/inference/tests/hawkes_adm4_test.py
+++ b/tick/hawkes/inference/tests/hawkes_adm4_test.py
@@ -69,9 +69,10 @@ class Test(unittest.TestCase):
         baseline_start = np.zeros(n_nodes) + .2
         adjacency_start = np.zeros((n_nodes, n_nodes)) + .2
 
-        learner = HawkesADM4(
-            self.decay, rho=rho, C=C, lasso_nuclear_ratio=lasso_nuclear_ratio,
-            n_threads=3, max_iter=10, verbose=False, em_max_iter=3)
+        learner = HawkesADM4(self.decay, rho=rho, C=C,
+                             lasso_nuclear_ratio=lasso_nuclear_ratio,
+                             n_threads=3, max_iter=10, verbose=False,
+                             em_max_iter=3, record_every=1)
         learner.fit(events[0], baseline_start=baseline_start,
                     adjacency_start=adjacency_start)
 
@@ -99,7 +100,7 @@ class Test(unittest.TestCase):
             np.cumsum(np.random.rand(4 + i)) for i in range(n_nodes)
         ] for _ in range(n_realizations)]
 
-        learner = HawkesADM4(self.decay)
+        learner = HawkesADM4(self.decay, record_every=1)
 
         msg = '^You must either call `fit` before `score` or provide events$'
         with self.assertRaisesRegex(ValueError, msg):

--- a/tick/hawkes/inference/tests/hawkes_expkern_test.py
+++ b/tick/hawkes/inference/tests/hawkes_expkern_test.py
@@ -154,7 +154,7 @@ class Test(InferenceTest):
             np.cumsum(np.random.rand(4 + i)) for i in range(n_nodes)
         ] for _ in range(n_realizations)]
 
-        learner = HawkesExpKern(self.decays)
+        learner = HawkesExpKern(self.decays, record_every=1)
 
         msg = '^You must either call `fit` before `score` or provide events$'
         with self.assertRaisesRegex(ValueError, msg):

--- a/tick/hawkes/inference/tests/hawkes_sumexpkern_test.py
+++ b/tick/hawkes/inference/tests/hawkes_sumexpkern_test.py
@@ -154,7 +154,7 @@ class Test(InferenceTest):
             np.cumsum(np.random.rand(4 + i)) for i in range(n_nodes)
         ] for _ in range(n_realizations)]
 
-        learner = HawkesSumExpKern(self.decays)
+        learner = HawkesSumExpKern(self.decays, record_every=1)
 
         msg = '^You must either call `fit` before `score` or provide events$'
         with self.assertRaisesRegex(ValueError, msg):

--- a/tick/solver/agd.py
+++ b/tick/solver/agd.py
@@ -156,28 +156,35 @@ class AGD(SolverFirstOrder):
         return x, y, t, step
 
     def _solve(self, x0: np.ndarray = None, step: float = None):
-        x, prev_x, y, grad_y, t, step, obj = \
+        minimizer, prev_minimizer, y, grad_y, t, step, obj = \
             self._initialize_values(x0, step)
         for n_iter in range(self.max_iter + 1):
             prev_t = t
-            prev_x[:] = x
-            prev_obj = obj
-            x, y, t, step = self._gradient_step(x, prev_x, y, grad_y, t,
-                                                prev_t, step)
+            prev_minimizer[:] = minimizer
+
+            # We will record on this iteration and we must be ready
+            if self._should_record_iter(n_iter):
+                prev_obj = self.objective(prev_minimizer)
+
+            minimizer, y, t, step = self._gradient_step(
+                minimizer, prev_minimizer, y, grad_y, t, prev_t, step)
             if step == 0:
                 print('Step equals 0... at %i' % n_iter)
                 break
-            rel_delta = relative_distance(x, prev_x)
-            obj = self.objective(x)
-            rel_obj = abs(obj - prev_obj) / abs(prev_obj)
-            converged = rel_obj < self.tol
-            # If converged, we stop the loop and record the last step
-            # in history
 
-            self._handle_history(n_iter, force=converged, obj=obj, x=x.copy(),
-                                 rel_delta=rel_delta, step=step,
-                                 rel_obj=rel_obj)
-            if converged:
-                break
-        self._set("solution", x)
-        return x
+            # Let's record metrics
+            if self._should_record_iter(n_iter):
+                rel_delta = relative_distance(minimizer, prev_minimizer)
+                obj = self.objective(minimizer)
+                rel_obj = abs(obj - prev_obj) / abs(prev_obj)
+                converged = rel_obj < self.tol
+                # If converged, we stop the loop and record the last step
+                # in history
+                self._handle_history(n_iter, force=converged, obj=obj,
+                                     x=minimizer.copy(), rel_delta=rel_delta,
+                                     step=step, rel_obj=rel_obj)
+                if converged:
+                    break
+
+        self._set("solution", minimizer)
+        return minimizer

--- a/tick/solver/base/solver.py
+++ b/tick/solver/base/solver.py
@@ -109,6 +109,20 @@ class Solver(Base):
         self._end_solve()
         return self.solution
 
+    def _should_record_iter(self, n_iter):
+        """Should solver record this iteration or not?
+        """
+        # If we are never supposed to record
+        if self.max_iter < self.print_every and \
+                self.max_iter < self.record_every:
+            return False
+        # Otherwise check that we are either at a specific moment or at the end
+        elif n_iter % self.print_every == 0 or n_iter % self.record_every == 0:
+            return True
+        elif n_iter == self.max_iter:
+            return True
+        return False
+
     def _handle_history(self, n_iter: int, force: bool = False, **kwargs):
         """Handles history for keywords and current iteration
 

--- a/tick/solver/bfgs.py
+++ b/tick/solver/bfgs.py
@@ -154,23 +154,24 @@ class BFGS(SolverFirstOrder):
         # A closure to maintain history along internal BFGS's iterations
         n_iter = [0]
         prev_x = x0.copy()
-        prev_obj = [obj]
 
         def insp(xk):
-            x = xk
-            rel_delta = relative_distance(x, prev_x)
-            prev_x[:] = x
-            obj = self.objective(x)
-            rel_obj = abs(obj - prev_obj[0]) / abs(prev_obj[0])
-            prev_obj[0] = obj
-            self._handle_history(n_iter[0], force=False, obj=obj, x=xk.copy(),
-                                 rel_delta=rel_delta, rel_obj=rel_obj)
+            if self._should_record_iter(n_iter[0]):
+                prev_obj = self.objective(prev_x)
+                x = xk
+                rel_delta = relative_distance(x, prev_x)
+
+                obj = self.objective(x)
+                rel_obj = abs(obj - prev_obj) / abs(prev_obj)
+                self._handle_history(n_iter[0], force=False, obj=obj,
+                                     x=xk.copy(), rel_delta=rel_delta,
+                                     rel_obj=rel_obj)
+            prev_x[:] = xk
             n_iter[0] += 1
 
         insp.n_iter = n_iter
         insp.self = self
         insp.prev_x = prev_x
-        insp.prev_obj = prev_obj
 
         # We simply call the scipy.optimize.fmin_bfgs routine
         x_min, f_min, _, _, _, _, _ = \


### PR DESCRIPTION
This is useful to avoid unnecessary computations that would slow down the solver.