### PR TITLE
#226 - Clang 6+ Werror

### DIFF
--- a/lib/cpp-test/array/array_gtest.cpp
+++ b/lib/cpp-test/array/array_gtest.cpp
@@ -7,9 +7,6 @@
 #include <random>
 #include <type_traits>
 
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
-
 #include <gtest/gtest.h>
 
 #define DEBUG_COSTLY_THROW 1
@@ -35,6 +32,7 @@
 #include "tick/array/array.h"
 #include "tick/array/dot.h"
 #include "tick/base/base.h"
+#include "tick/base/serialization.h"
 
 namespace {
 
@@ -266,9 +264,9 @@ TYPED_TEST(ArrayTest, Size) {
 TYPED_TEST(ArrayTest, InitList) {
   using VT = typename TypeParam::value_type;
 
-  std::array<VT, 6> vals = {static_cast<VT>(0.0), static_cast<VT>(1.0),
+  std::array<VT, 6> vals = {{static_cast<VT>(0.0), static_cast<VT>(1.0),
                             static_cast<VT>(2.0), static_cast<VT>(4.0),
-                            static_cast<VT>(8.0), static_cast<VT>(16.0)};
+                            static_cast<VT>(8.0), static_cast<VT>(16.0)}};
 
   TypeParam arr{vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]};
 

--- a/lib/cpp-test/base/utils_gtest.cpp
+++ b/lib/cpp-test/base/utils_gtest.cpp
@@ -16,7 +16,7 @@
 #include "tick/base/time_func.h"
 
 #include <gtest/gtest.h>
-#include <cereal/archives/json.hpp>
+#include "tick/base/serialization.h"
 
 struct MapFunctorsUnary {
   MapFunctorsUnary(std::size_t n) : data(n, 0) {}
@@ -349,7 +349,7 @@ TEST(DebugTest, PrintSparseArray) {
 #ifdef ADD_MAIN
 int main(int argc, char** argv) {
 #ifdef _WIN32
-  std::cout << "Skipping tests in " __FILE__ 
+  std::cout << "Skipping tests in " __FILE__
             << " on windows due to strangeness" << std::endl;
 #else
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
go through common cereal path to ignore warnings within cereal to ignore  Werror in cereal code