### PR TITLE
#252 deprecate python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ matrix:
     services: docker
     env:
       - DOCKER_IMAGE=xdatainitiative/tick_ubuntu:1.4
-      - PYVER=3.4.6
-  - os: linux
-    services: docker
-    env:
-      - DOCKER_IMAGE=xdatainitiative/tick_ubuntu:1.4
       - PYVER=3.5.3
   - os: linux
     services: docker
@@ -30,19 +25,13 @@ matrix:
   - os: osx
     language: generic
     sudo: required
-    env: 
-      - PYVER=3.4.6
-    osx_image: xcode9.1
-  - os: osx
-    language: generic
-    sudo: required
     env:
       - PYVER=3.5.3
     osx_image: xcode9.1
   - os: osx
     language: generic
     sudo: required
-    env: 
+    env:
       - PYVER=3.6.1
     osx_image: xcode9.1
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 ### Requirements
 
-_tick_ currently works on Linux/OSX (Windows is experimental) systems and requires Python 3.4 or newer. Please have the required Python dependencies in your Python environment:
+_tick_ currently works on Linux/OSX (Windows is experimental) systems and requires Python 3.5 or newer. Please have the required Python dependencies in your Python environment:
 
 - numpy
 - scipy
@@ -33,12 +33,12 @@ Installation may take a few minutes to build and link C++ extensions. At this po
 
 ### Manual Install - Linux -OSX
 
-First you need to clone the repository with 
+First you need to clone the repository with
 
     git clone https://github.com/X-DataInitiative/tick.git
 
 and then initialize its submodules (such as cereal) with
- 
+
     git submodule update --init
 
 It's possible to manually build and install tick via the setup.py script. To do both in one step, do:
@@ -64,10 +64,10 @@ This will build all required C++ extensions, and install the extensions in your 
     numpydoc-0.7.0-py2.py3-none-any.whl
     scipy-0.19.*-cp36-cp36m-win_amd64.whl
 
-  Note: To ascertain which version of the wheel files to download you can run 
+  Note: To ascertain which version of the wheel files to download you can run
 
     python3 -c "import distutils; from distutils import sysconfig; print(sysconfig.get_config_var('SO'))"
- 
+
   Install the wheel files with pip - this is not required for Anaconda
 
     pip install wheel
@@ -80,7 +80,7 @@ This will build all required C++ extensions, and install the extensions in your 
     /path/to/VS/VC/Auxiliary/Build/vcvarsall.bat [amd64,x86]
 
   The default path for "vcvarsall.bat" for Visual Studio Build Tools:
-  
+
     C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat [amd64,x86]
 
   Build Tick C++ sources
@@ -123,7 +123,7 @@ Once "mkn" is installed on your system, you should execture the shell script "./
 
 As with tick in general, this requires python3 and all python pre-requisites. numpy/scipy/etc
 
-This method is provided mainly for developers to decrease compilation times. 
+This method is provided mainly for developers to decrease compilation times.
 
 To use [ccache](https://ccache.samba.org/) (or similar) with mkn, edit your ~/.maiken/settings.yaml file so it looks like one [here](https://github.com/Dekken/maiken/wiki/Alternative-configs) - this can greatly decrease repeated compilation times. ccache is a third party tool which may have to be installed manually on your system. ccache does not work on Windows.
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ _tick_ is a machine learning library for Python 3. The focus is on statistical l
 The core of the library is an optimization module providing model computational classes, solvers and proximal operators for regularization. It comes also with inference and simulation tools intended for end-users who for example can easily:
 
 - Perform linear, logistic or Poisson regression
-- Simulate point Hawkes processes with standard or exotic kernels. 
+- Simulate point Hawkes processes with standard or exotic kernels.
 - Infer Hawkes models with various assumptions on the kernels: exponential or sum of exponential kernels, linear combination of basis kernels, sparse interactions, etc.
 
 A comprehensive list of examples can be found at
 
-- [https://x-datainitiative.github.io/tick/auto_examples/index.html](https://x-datainitiative.github.io/tick/auto_examples/index.html) 
+- [https://x-datainitiative.github.io/tick/auto_examples/index.html](https://x-datainitiative.github.io/tick/auto_examples/index.html)
 
 and the documentation is available at
 
@@ -47,17 +47,17 @@ The <i>tick</i> library is released with the support of Intel®. It uses the Int
 _tick_ is used for many industrial applications including:
 
 * [A joint work](https://portail.polytechnique.edu/datascience/fr/node/329) with the French national social security (CNAMTS) to analyses a huge health-care database, that describes the medical care provided to most of the French citizens. For this project, _tick_ is used to detect weak signals in pharmacovigilance, in order quantify the impact of drugs exposures to the occurrence of adverse events.
-   
+
 * High-frequency order book modeling in finance, in order to understand the interactions between different event types and/or between different assets, leveraging the full time resolution available in the original data.
 
-* Analyze the propagation of information in social media. Thanks to a dataset collected during 2017's presidential French election campaign on Twitter, _tick_ is used to recover, for each topic, the network across which information spreads inside the political sphere. 
-  
+* Analyze the propagation of information in social media. Thanks to a dataset collected during 2017's presidential French election campaign on Twitter, _tick_ is used to recover, for each topic, the network across which information spreads inside the political sphere.
+
 
 ## Quick setup
 
 ### Requirements
 
-_tick_ currently works on Linux/OSX (Windows is experimental) systems and requires Python 3.4 or newer. Please have the required Python dependencies in your Python environment:
+_tick_ currently works on Linux/OSX (Windows is experimental) systems and requires Python 3.5 or newer. Please have the required Python dependencies in your Python environment:
 
 ### Install using _pip_
 
@@ -82,12 +82,12 @@ Please see the [INSTALL document](INSTALL.md)
 
 ### Documentation
 
-Documentation is available on 
+Documentation is available on
 
 - [https://x-datainitiative.github.io/tick](https://x-datainitiative.github.io/tick/)
 
 This documentation is built with `Sphinx` and can be compiled and used locally by running `make html` from within the `doc` directory. This obviously needs to have `Sphinx` installed. Several tutorials and code-samples are available in the documentation.
- 
+
 ### Communication
 
 To reach the developers of _tick_, please join our community channel on Gitter (https://gitter.im/xdata-tick).
@@ -100,7 +100,7 @@ If you use _tick_ in a scientific publication, we would appreciate citations. Yo
 
     @ARTICLE{2017arXiv170703003B,
       author = {{Bacry}, E. and {Bompaire}, M. and {Ga{\"i}ffas}, S. and {Poulsen}, S.},
-      title = "{tick: a Python library for statistical learning, with 
+      title = "{tick: a Python library for statistical learning, with
         a particular emphasis on time-dependent modeling}",
       journal = {ArXiv e-prints},
       eprint = {1707.03003},

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,8 @@ build_script:
   # doesnt exist for somereason?
   - mkdir -p "C:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\cppwinrt"
 
+  # Python 3.7 TODO
+
   # Python 3.6
   - cat appveyor/pip/numpy/numpy-1.14.0+mkl-cp36* > appveyor/pip/numpy-1.14.0+mkl-cp36-cp36m-win_amd64.whl
   - C:\Python36-x64\Scripts\pip install appveyor\pip\numpy-1.14.0+mkl-cp36-cp36m-win_amd64.whl
@@ -70,8 +72,6 @@ build_script:
   # - C:\Python35-x64\python setup.py bdist_wheel
   # - rm -rf build
   # - rm -rf lib\bin
-
-  # Python 3.4 : Building wheels for pandas is currently failing, having trouble with pandas
 
 artifacts:
   - path: "dist\\*.whl"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-numpydoc
+numpydoc==0.7.0
 scipy
 matplotlib
 scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ if os.name == 'posix':
 # Directory containing built .so files before they are moved either
 # in source (with build flag --inplace) or to site-packages (by install)
 #
-# E.g. build/lib.macosx-10.11-x86_64-3.4
+# E.g. build/lib.macosx-10.11-x86_64-3.5
 build_dir = "build/lib.{}-{}".format(distutils.util.get_platform(),
                                      sys.version[0:3])
 
@@ -865,8 +865,8 @@ setup(name="tick",
                    'Operating System :: POSIX',
                    'Operating System :: Unix',
                    'Operating System :: MacOS',
-                   'Programming Language :: Python :: 3.4',
                    'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',
+                   'Programming Language :: Python :: 3.7',
                    'License :: OSI Approved :: BSD License'],
       )

--- a/tools/docker/tick_ubuntu/Dockerfile
+++ b/tools/docker/tick_ubuntu/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /tick
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y build-essential cmake curl git swig patchelf unzip libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev curl llvm libncurses5-dev libncursesw5-dev \
-xz-utils tk-dev 
+xz-utils tk-dev
 
 ENV PATH="/root/.pyenv/bin:$PATH"
 
@@ -16,12 +16,11 @@ RUN git clone https://github.com/google/googletest.git && \
 	rm -rf googletest
 
 # Installing necessary python versions
-RUN pyenv install 3.4.6 && pyenv install 3.5.3 && pyenv install 3.6.1
+RUN pyenv install 3.5.3 && pyenv install 3.6.1
 
-COPY requirements.txt requirements.txt 
+COPY requirements.txt requirements.txt
 
 RUN eval "$(pyenv init -)" && \
-    pyenv local 3.4.6 && pip install -r requirements.txt -U pip && pip install tensorflow && \
     pyenv local 3.5.3 && pip install -r requirements.txt -U pip && pip install tensorflow && \
     pyenv local 3.6.1 && pip install -r requirements.txt -U pip && pip install tensorflow
 


### PR DESCRIPTION
Deprecate python 3.4 - both travis and appveyor have issues with Pandas on 3.4

Python 3.7 is being released next month (supposedly) so preparing for that to follow.