### PR TITLE
Longitudinal preprocessor parallelization

### DIFF
--- a/lib/cpp/preprocessing/longitudinal_features_lagger.cpp
+++ b/lib/cpp/preprocessing/longitudinal_features_lagger.cpp
@@ -6,34 +6,38 @@
 
 #include "tick/preprocessing/longitudinal_features_lagger.h"
 
+
 LongitudinalFeaturesLagger::LongitudinalFeaturesLagger(
-    const SBaseArrayDouble2dPtrList1D &features,
-    const SArrayULongPtr n_lags)
-    : n_intervals(features[0]->n_rows()),
-      n_lags(n_lags),
-      n_samples(features.size()),
-      n_observations(n_samples * n_intervals),
-      n_features(features[0]->n_cols()),
-      n_lagged_features(n_lags->sum() + n_lags->size()) {
-  col_offset = ArrayULong(n_lags->size());
-  col_offset.init_to_zero();
-  if (n_features != n_lags->size()) {
-    TICK_ERROR("Features matrix column number should match n_lags length.");
-  }
-  if ((*n_lags)[0] >= n_intervals) {
-    TICK_ERROR("n_lags elements must be between 0 and (n_intervals - 1).");
-  }
+    ulong n_intervals,
+    SArrayULongPtr _n_lags)
+    : n_intervals(n_intervals),
+      n_lags(_n_lags),
+      n_features(_n_lags->size()),
+      n_lagged_features(_n_lags->size() + _n_lags->sum()) {
+  if (n_lags != nullptr) compute_col_offset(n_lags);
+}
+
+void LongitudinalFeaturesLagger::compute_col_offset(const SArrayULongPtr n_lags) {
+  ArrayULong col_offset_temp = ArrayULong(n_lags->size());
+  col_offset_temp.init_to_zero();
   for (ulong i(1); i < n_lags->size(); i++) {
     if ((*n_lags)[i] >= n_intervals) {
       TICK_ERROR("n_lags elements must be between 0 and (n_intervals - 1).");
     }
-    col_offset[i] = col_offset[i - 1] + (*n_lags)[i-1] + 1;
+    col_offset_temp[i] = col_offset_temp[i - 1] + (*n_lags)[i-1] + 1;
   }
+  col_offset = col_offset_temp.as_sarray_ptr();
 }
 
 void LongitudinalFeaturesLagger::dense_lag_preprocessor(ArrayDouble2d &features,
                                                         ArrayDouble2d &out,
                                                         ulong censoring) const {
+  if (n_intervals != features.n_rows()) {
+    TICK_ERROR("Features matrix rows count should match n_intervals.");
+  }
+  if (n_features != features.n_cols()) {
+    TICK_ERROR("Features matrix column count should match n_lags length.");
+  }
   if (out.n_cols() != n_lagged_features) {
     TICK_ERROR(
         "n_columns of &out should be equal to n_features + sum(n_lags).");
@@ -47,8 +51,9 @@ void LongitudinalFeaturesLagger::dense_lag_preprocessor(ArrayDouble2d &features,
     n_cols_feature = (*n_lags)[feature] + 1;
     for (ulong j = 0; j < n_intervals; j++) {
       row = j;
-      col = col_offset[feature];
-      value = features(row, feature);
+      col = (*col_offset)[feature];
+      // use view_row instead of (row, feature) to be const
+      value = view_row(features, row)[feature];
       max_col = col + n_cols_feature;
       if (value != 0) {
         while (row < censoring && col < max_col) {
@@ -68,6 +73,7 @@ void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
                                                          ArrayULong &out_col,
                                                          ArrayDouble &out_data,
                                                          ulong censoring) const {
+  // TODO: add checks here ? Or do them in Python ?
   ulong j(0), r, c, offset, new_col, max_col;
   double value;
 
@@ -75,7 +81,7 @@ void LongitudinalFeaturesLagger::sparse_lag_preprocessor(ArrayULong &row,
     value = data[i];
     r = row[i];
     c = col[i];
-    offset = col_offset[c];
+    offset = (*col_offset)[c];
     max_col = offset + (*n_lags)[c] + 1;
     new_col = offset;
 

--- a/lib/cpp/preprocessing/sparse_longitudinal_features_product.cpp
+++ b/lib/cpp/preprocessing/sparse_longitudinal_features_product.cpp
@@ -7,10 +7,6 @@
 #include "tick/preprocessing/sparse_longitudinal_features_product.h"
 #include <map>
 
-SparseLongitudinalFeaturesProduct::SparseLongitudinalFeaturesProduct(
-    const SBaseArrayDouble2dPtrList1D &features)
-    : n_features(features[0]->n_cols()) {}
-
 ulong SparseLongitudinalFeaturesProduct::get_feature_product_col(
     ulong col1, ulong col2, ulong n_cols) const {
   if (col1 > col2) {  // ensure we have the right order as the following formula

--- a/lib/include/tick/preprocessing/sparse_longitudinal_features_product.h
+++ b/lib/include/tick/preprocessing/sparse_longitudinal_features_product.h
@@ -16,8 +16,11 @@ class SparseLongitudinalFeaturesProduct {
   ulong n_features;
 
  public:
+  // This exists soley for cereal/swig
+  SparseLongitudinalFeaturesProduct() = default;
+
   explicit SparseLongitudinalFeaturesProduct(
-      const SBaseArrayDouble2dPtrList1D &features);
+      const ulong n_features): n_features(n_features) {}
 
   inline ulong get_feature_product_col(ulong col1, ulong col2,
                                        ulong n_cols) const;
@@ -28,7 +31,12 @@ class SparseLongitudinalFeaturesProduct {
                                ArrayDouble &out_data) const;
 
   template <class Archive>
-  void serialize(Archive &ar) {
+  void load(Archive &ar) {
+    ar(CEREAL_NVP(n_features));
+  }
+
+  template <class Archive>
+  void save(Archive &ar) const {
     ar(CEREAL_NVP(n_features));
   }
 };

--- a/lib/swig/preprocessing/longitudinal_features_lagger.i
+++ b/lib/swig/preprocessing/longitudinal_features_lagger.i
@@ -4,24 +4,25 @@
 #include "tick/preprocessing/longitudinal_features_lagger.h"
 %}
 
+%include serialization.i
+
 class LongitudinalFeaturesLagger {
 
  public:
-  LongitudinalFeaturesLagger(const SBaseArrayDouble2dPtrList1D &features,
-                             const SArrayULongPtr n_lags);
+  // This exists soley for cereal/swig
+  LongitudinalFeaturesLagger();
+
+  LongitudinalFeaturesLagger(ulong n_intervals,
+                             SArrayULongPtr n_lags);
 
   void dense_lag_preprocessor(ArrayDouble2d &features,
                               ArrayDouble2d &out,
                               ulong censoring) const;
 
-  void sparse_lag_preprocessor(ArrayULong &row,
-                               ArrayULong &col,
-                               ArrayDouble &data,
-                               ArrayULong &out_row,
-                               ArrayULong &out_col,
-                               ArrayDouble &out_data,
+  void sparse_lag_preprocessor(ArrayULong &row, ArrayULong &col,
+                               ArrayDouble &data, ArrayULong &out_row,
+                               ArrayULong &out_col, ArrayDouble &out_data,
                                ulong censoring) const;
-
 };
 
 TICK_MAKE_PICKLABLE(LongitudinalFeaturesLagger);

--- a/lib/swig/preprocessing/sparse_longitudinal_features_product.i
+++ b/lib/swig/preprocessing/sparse_longitudinal_features_product.i
@@ -4,10 +4,15 @@
 #include "tick/preprocessing/sparse_longitudinal_features_product.h"
 %}
 
+%include serialization.i
+
 class SparseLongitudinalFeaturesProduct {
 
   public:
-    SparseLongitudinalFeaturesProduct(const SBaseArrayDouble2dPtrList1D &features);
+    // This exists soley for cereal/swig
+    SparseLongitudinalFeaturesProduct();
+
+    SparseLongitudinalFeaturesProduct(const ulong n_features);
 
     void sparse_features_product(ArrayULong &row,
                                  ArrayULong &col,

--- a/tick/preprocessing/base/longitudinal_preprocessor.py
+++ b/tick/preprocessing/base/longitudinal_preprocessor.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from tick.base import Base
+from multiprocessing import cpu_count
 
 
 class LongitudinalPreprocessor(ABC, Base):
@@ -14,9 +15,14 @@ class LongitudinalPreprocessor(ABC, Base):
         set to the number of cores.
     """
 
-    def __init__(self, n_jobs=-1):
+    _attrinfos = {'n_jobs': {'writable': True}}
+
+    def __init__(self, n_jobs=1):
         Base.__init__(self)
-        self.n_jobs = n_jobs
+        if n_jobs == -1:
+            self.n_jobs = cpu_count()
+        else:
+            self.n_jobs = n_jobs
 
     @abstractmethod
     def fit(self, features, labels, censoring) -> None:

--- a/tick/preprocessing/tests/longitudinal_features_lagger_test.py
+++ b/tick/preprocessing/tests/longitudinal_features_lagger_test.py
@@ -4,6 +4,9 @@ import numpy as np
 from scipy.sparse import csr_matrix
 import unittest
 from tick.preprocessing import LongitudinalFeaturesLagger
+from tick.preprocessing.build.preprocessing import LongitudinalFeaturesLagger\
+    as _LongitudinalFeaturesLagger
+import pickle
 
 
 class Test(unittest.TestCase):
@@ -13,6 +16,7 @@ class Test(unittest.TestCase):
             np.array([[1, 1, 1], [0, 0, 1], [1, 1, 0]], dtype="float64")
         ]
         self.sparse_features = [csr_matrix(f) for f in self.features]
+        self.n_intervals, self.n_features = self.features[0].shape
 
         self.censoring = np.array([2, 3], dtype="uint64")
 
@@ -26,15 +30,45 @@ class Test(unittest.TestCase):
         self.n_lags = np.array([1, 2, 1], dtype="uint64")
 
     def test_dense_pre_convolution(self):
-        feat_prod, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags)\
+        lagged_feat, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags,
+                                                       n_jobs=1)\
             .fit_transform(self.features, censoring=self.censoring)
-        np.testing.assert_equal(feat_prod, self.expected_output)
+        np.testing.assert_equal(lagged_feat, self.expected_output)
 
     def test_sparse_pre_convolution(self):
-        feat_prod, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags)\
+        lagged_feat, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags,
+                                                       n_jobs=1)\
             .fit_transform(self.sparse_features, censoring=self.censoring)
-        feat_prod = [f.todense() for f in feat_prod]
-        np.testing.assert_equal(feat_prod, self.expected_output)
+        lagged_feat = [f.todense() for f in lagged_feat]
+        np.testing.assert_equal(lagged_feat, self.expected_output)
+
+    def test_parallelization_sparse(self):
+        lagged_feat, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags,
+                                                       n_jobs=1) \
+            .fit_transform(self.sparse_features, censoring=self.censoring)
+        p_lagged_feat, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags,
+                                                         n_jobs=-1)\
+            .fit_transform(self.sparse_features, censoring=self.censoring)
+        lagged_feat = [f.toarray() for f in lagged_feat]
+        p_lagged_feat = [f.toarray() for f in p_lagged_feat]
+        np.testing.assert_equal(lagged_feat, p_lagged_feat)
+
+    def test_parallelization_dense(self):
+        lagged_feat, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags,
+                                                       n_jobs=1) \
+            .fit_transform(self.features, censoring=self.censoring)
+        p_lagged_feat, _, _ = LongitudinalFeaturesLagger(n_lags=self.n_lags,
+                                                         n_jobs=-1)\
+            .fit_transform(self.features, censoring=self.censoring)
+        np.testing.assert_equal(lagged_feat, p_lagged_feat)
+
+    def test_serialization(self):
+        python = LongitudinalFeaturesLagger(n_lags=self.n_lags, n_jobs=1)
+        cpp = _LongitudinalFeaturesLagger(self.n_intervals, self.n_lags)
+        pickle.loads(pickle.dumps(python))
+        pickle.loads(pickle.dumps(cpp))
+        # Cannot check equality as CPP underlying objects will not be created in
+        # the same memory slot
 
 
 if __name__ == "__main__":

--- a/tick/preprocessing/tests/longitudinal_features_product_test.py
+++ b/tick/preprocessing/tests/longitudinal_features_product_test.py
@@ -4,6 +4,9 @@ import numpy as np
 from scipy.sparse import csr_matrix
 import unittest
 from tick.preprocessing import LongitudinalFeaturesProduct
+from tick.preprocessing.build.preprocessing \
+    import SparseLongitudinalFeaturesProduct
+import pickle
 
 
 class Test(unittest.TestCase):
@@ -24,6 +27,8 @@ class Test(unittest.TestCase):
             csr_matrix(f) for f in self.infinite_exposures
         ]
 
+        self.n_intervals, self.n_features = self.finite_exposures[0].shape
+
     def test_finite_features_product(self):
         expected_output = \
             [np.array([[0, 1, 0, 0, 0, 0],
@@ -35,7 +40,7 @@ class Test(unittest.TestCase):
                        [1, 1, 0, 1, 0, 0],
                        ], dtype="float64")
              ]
-        pp = LongitudinalFeaturesProduct("finite")
+        pp = LongitudinalFeaturesProduct("finite", n_jobs=1)
 
         feat_prod, _, _ = pp.fit_transform(self.finite_exposures)
         np.testing.assert_equal(feat_prod, expected_output)
@@ -55,11 +60,36 @@ class Test(unittest.TestCase):
                        [0, 0, 0, 0, 0, 0],
                        ], dtype="float64")
              ]
-        sparse_feat = [csr_matrix(f) for f in self.infinite_exposures]
-        feat_prod, _, _ = LongitudinalFeaturesProduct("infinite")\
-            .fit_transform(sparse_feat)
+        feat_prod, _, _ = LongitudinalFeaturesProduct("infinite", n_jobs=1)\
+            .fit_transform(self.sparse_infinite_exposures)
         feat_prod = [f.toarray() for f in feat_prod]
         np.testing.assert_equal(feat_prod, expected_output)
+
+    def test_parallelization(self):
+        for exp_type in ['finite', 'infinite']:
+            feat_prod, _, _ = LongitudinalFeaturesProduct(exp_type, n_jobs=1)\
+                .fit_transform(self.sparse_infinite_exposures)
+            p_feat_prod, _, _ = LongitudinalFeaturesProduct(exp_type,
+                                                            n_jobs=-1)\
+                .fit_transform(self.sparse_infinite_exposures)
+            feat_prod = [f.toarray() for f in feat_prod]
+            p_feat_prod = [f.toarray() for f in p_feat_prod]
+            np.testing.assert_equal(feat_prod, p_feat_prod)
+
+        exp_type = 'finite'
+        feat_prod, _, _ = LongitudinalFeaturesProduct(exp_type, n_jobs=1) \
+            .fit_transform(self.finite_exposures)
+        p_feat_prod, _, _ = LongitudinalFeaturesProduct(exp_type, n_jobs=-1) \
+            .fit_transform(self.finite_exposures)
+        np.testing.assert_equal(feat_prod, p_feat_prod)
+
+    def test_serialization(self):
+        python = LongitudinalFeaturesProduct()
+        cpp = SparseLongitudinalFeaturesProduct(self.n_features)
+        pickle.loads(pickle.dumps(python))
+        pickle.loads(pickle.dumps(cpp))
+        # Cannot check equality as CPP underlying objects will not be created in
+        # the same memory slot
 
 
 if __name__ == "__main__":

--- a/tick/survival/convolutional_sccs.py
+++ b/tick/survival/convolutional_sccs.py
@@ -355,7 +355,8 @@ class ConvSCCS(ABC, Base):
             features, labels, censoring)
         # split the data with stratified KFold
         kf = StratifiedKFold(n_folds, shuffle, self.random_state)
-        labels_interval = np.nonzero(p_labels)[1]
+        # labels_interval = np.nonzero(p_labels)[1]
+        labels_interval = [np.nonzero(arr)[0][0] for arr in p_labels]
 
         # Training loop
         model_global_parameters = {


### PR DESCRIPTION
Make the longitudinal preprocessors serializable and make them parallel using python.multiprocessing.

To avoid sending the whole instance of each class to spawned or forked processes, I used an initializer in the process Pool to create a cpp object instance per process. I also used higher-order functions for the same purpose.
The drawback of doing so is having the pool initializers (`_inject_cpp_object` methods) using `global` variables to store the cpp objects. This should not have dire consequences in the multiprocessing context, as each process possesses its own namespace. However, such methods could cause some trouble if called outside of this context (rogue/monkey user).
