### PR TITLE
Make ASVRG converge more properly with several threads

### DIFF
--- a/examples/plot_asynchronous_stochastic_solver.py
+++ b/examples/plot_asynchronous_stochastic_solver.py
@@ -31,9 +31,9 @@ np.random.seed(seed)
 n_samples = 40000
 n_features = 20000
 sparsity = 1e-4
-penalty_strength = 1e-6
+penalty_strength = 1e-5
 
-weights = weights_sparse_gauss(n_features, nnz=10)
+weights = weights_sparse_gauss(n_features, nnz=1000)
 intercept = 0.2
 features = sparse.rand(n_samples, n_features, density=sparsity, format='csr')
 
@@ -65,7 +65,7 @@ for n_threads in test_n_threads:
 
 plot_history(svrg_list, x="time", dist_min=True, log_scale=True,
              labels=svrg_labels, show=False)
-plt.ylim([3e-3, 0.3])
+
 plt.ylabel('log distance to optimal objective', fontsize=14)
 plt.tight_layout()
 plt.show()

--- a/lib/cpp/prox/prox.cpp
+++ b/lib/cpp/prox/prox.cpp
@@ -107,6 +107,11 @@ void TProx<T, K>::set_positive(bool positive) {
   this->positive = positive;
 }
 
+template <class T, class K>
+bool TProx<T, K>::is_in_range(ulong i) const {
+  return !has_range || ((i >= start) && (i < end));
+}
+
 template class TProx<double, double>;
 template class TProx<float, float>;
 

--- a/lib/cpp/prox/prox_l1w.cpp
+++ b/lib/cpp/prox/prox_l1w.cpp
@@ -70,6 +70,11 @@ void TProxL1w<T, K>::call(const Array<K> &coeffs, const Array<T> &step,
   }
 }
 
+template <class T, class K>
+T TProxL1w<T, K>::call_single_with_index(T x, T step, ulong i) const {
+  return is_in_range(i)? call_single(x, step, (*weights)[i - start]): x;
+}
+
 // We cannot implement only TProxL1w<T, K>::call_single(T x, T step) since we
 // need to know i to find the weight
 template <class T, class K>

--- a/lib/cpp/prox/prox_separable.cpp
+++ b/lib/cpp/prox/prox_separable.cpp
@@ -53,6 +53,11 @@ T TProxSeparable<T, K>::call_single(T x, T step) const {
 }
 
 template <class T, class K>
+T TProxSeparable<T, K>::call_single_with_index(T x, T step, ulong i) const {
+  return is_in_range(i) ? call_single(x, step): x;
+}
+
+template <class T, class K>
 T TProxSeparable<T, K>::call_single(T x, T step, ulong n_times) const {
   if (n_times >= 1) {
     for (ulong r = 0; r < n_times; ++r) {
@@ -71,15 +76,10 @@ void TProxSeparable<T, K>::call_single(ulong i, const Array<K> &coeffs, T step,
                << "::call_single "
                << "i= " << i << " while coeffs.size()=" << coeffs.size());
   } else {
-    if (has_range) {
-      if ((i >= start) && (i < end)) {
-        out[i] = call_single(coeffs[i], step);
-      } else {
-        out[i] = coeffs.get_data_index(i);
-      }
-    } else {
+    if (is_in_range(i))
       out[i] = call_single(coeffs[i], step);
-    }
+    else
+      out[i] = coeffs.get_data_index(i);
   }
 }
 
@@ -92,15 +92,10 @@ void TProxSeparable<T, K>::call_single(ulong i, const Array<K> &coeffs, T step,
                << "::call_single "
                << "i= " << i << " while coeffs.size()=" << coeffs.size());
   } else {
-    if (has_range) {
-      if ((i >= start) && (i < end)) {
-        out[i] = call_single(coeffs[i], step, n_times);
-      } else {
-        out.set_data_index(i, coeffs[i]);
-      }
-    } else {
+    if (is_in_range(i))
       out[i] = call_single(coeffs[i], step, n_times);
-    }
+    else
+      out[i] = coeffs.get_data_index(i);
   }
 }
 

--- a/lib/include/tick/prox/prox.h
+++ b/lib/include/tick/prox/prox.h
@@ -84,6 +84,9 @@ class DLL_PUBLIC TProx {
 
   virtual void set_positive(bool positive);
 
+  //! @brief tells whether prox should be applied to this index or not
+  bool is_in_range(ulong i) const;
+
   template <class Archive>
   void serialize(Archive& ar) {
     ar(CEREAL_NVP(strength), CEREAL_NVP(has_range), CEREAL_NVP(start),

--- a/lib/include/tick/prox/prox_l1w.h
+++ b/lib/include/tick/prox/prox_l1w.h
@@ -17,6 +17,7 @@ class DLL_PUBLIC TProxL1w : public TProxSeparable<T, K> {
 
  public:
   using TProxSeparable<T, K>::get_class_name;
+  using TProxSeparable<T, K>::is_in_range;
 
  public:
   using SArrayTPtr = std::shared_ptr<SArray<T>>;
@@ -53,6 +54,8 @@ class DLL_PUBLIC TProxL1w : public TProxSeparable<T, K> {
 
   void call_single(ulong i, const Array<K> &coeffs, T step, Array<K> &out,
                    ulong n_times) const override;
+
+  T call_single_with_index(T x, T step, ulong i) const override;
 
   T value(const Array<K> &coeffs, ulong start, ulong end) override;
 

--- a/lib/include/tick/prox/prox_separable.h
+++ b/lib/include/tick/prox/prox_separable.h
@@ -20,6 +20,7 @@ class DLL_PUBLIC TProxSeparable : public TProx<T, K> {
  public:
   using TProx<T, K>::call;
   using TProx<T, K>::get_class_name;
+  using TProx<T, K>::is_in_range;
 
  public:
   // This exists soley for cereal/swig
@@ -59,6 +60,10 @@ class DLL_PUBLIC TProxSeparable : public TProx<T, K> {
 
   //! @brief apply prox on a single value
   virtual T call_single(T x, T step) const;
+
+  //! @brief apply prox on a single value with specifying index
+  //! @note this is useful for prox that don't apply the exact same operation to all indexes
+  virtual T call_single_with_index(T x, T step, ulong i) const;
 
  private:
   //! @brief apply prox on a single value several times


### PR DESCRIPTION
Storing `iterate[j] - descent_direction` in the shared `iterate` vector before applying prox was causing a potential collision that is problematic to reach high precision levels.
In this PR, the shared iterate vector is updated only once, directly to the expected value.

Before fixing
![asvrg_failing](https://user-images.githubusercontent.com/1908833/44857347-e9e13d00-ac6f-11e8-9799-1981915a805f.png)

After fixing
![asvrg_fixed](https://user-images.githubusercontent.com/1908833/44857352-ee0d5a80-ac6f-11e8-95a6-4208708886c9.png)

I had to add `is_in_range` method to call directly `T call_single(T x, T step)` on the correct indexes on the iterate. Originally, the prox itself was checking if it should be called on a specific index or not.