### PR TITLE
Remove requirement for cereal JSON archives in Python/etc

### DIFF
--- a/lib/cpp-test/array/array_gtest.cpp
+++ b/lib/cpp-test/array/array_gtest.cpp
@@ -694,9 +694,9 @@ void TestSerialization2D() {
 
 }  // namespace
 
-TYPED_TEST(ArrayTest, EmptySerializationJSON) {
+TYPED_TEST(ArrayTest, EmptySerializationPortableBinary) {
   SCOPED_TRACE("");
-  ::TestEmptySerialization<cereal::JSONInputArchive, cereal::JSONOutputArchive,
+  ::TestEmptySerialization<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive,
                            TypeParam>();
 }
 
@@ -706,10 +706,10 @@ TYPED_TEST(ArrayTest, EmptySerializationBinary) {
                            TypeParam>();
 }
 
-TYPED_TEST(Array2dTest, EmptySerializationJSON) {
+TYPED_TEST(Array2dTest, EmptySerializationPortableBinary) {
   SCOPED_TRACE("");
-  ::TestEmptySerialization2D<cereal::JSONInputArchive,
-                             cereal::JSONOutputArchive, TypeParam>();
+  ::TestEmptySerialization2D<cereal::PortableBinaryInputArchive,
+                             cereal::PortableBinaryOutputArchive, TypeParam>();
 }
 
 TYPED_TEST(Array2dTest, EmptySerializationBinary) {
@@ -718,9 +718,9 @@ TYPED_TEST(Array2dTest, EmptySerializationBinary) {
                              cereal::PortableBinaryOutputArchive, TypeParam>();
 }
 
-TYPED_TEST(ArrayTest, SerializationJSON) {
+TYPED_TEST(ArrayTest, SerializationPortableBinary) {
   SCOPED_TRACE("");
-  ::TestSerialization<cereal::JSONInputArchive, cereal::JSONOutputArchive,
+  ::TestSerialization<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive,
                       TypeParam>();
 }
 
@@ -730,9 +730,9 @@ TYPED_TEST(ArrayTest, SerializationBinary) {
                       TypeParam>();
 }
 
-TYPED_TEST(Array2dTest, SerializationJSON) {
+TYPED_TEST(Array2dTest, SerializationPortableBinary) {
   SCOPED_TRACE("");
-  ::TestSerialization2D<cereal::JSONInputArchive, cereal::JSONOutputArchive,
+  ::TestSerialization2D<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive,
                         TypeParam>();
 }
 

--- a/lib/cpp-test/array/serializer_gtest.cpp
+++ b/lib/cpp-test/array/serializer_gtest.cpp
@@ -8,15 +8,15 @@
 
 TEST(Serialize, ForceLoadError) {
   // CSR matrix example from https://en.wikipedia.org/wiki/Sparse_matrix
-  ArrayDouble data{10, 20, 30, 40, 50, 60, 70, 80};
+  ArrayFloat data{10, 20, 30, 40, 50, 60, 70, 80};
   Array<INDICE_TYPE> row_indices{0, 2, 4, 7, 8};
   Array<INDICE_TYPE> indices{0, 1, 1, 3, 2, 3, 4, 5};
-  SparseArrayDouble2d sparse_array(4, 6, row_indices.data(), indices.data(), data.data());
+  SparseArrayFloat2d sparse_array(4, 6, row_indices.data(), indices.data(), data.data());
   bool caught = false;
   try {
-    std::string file_name = "test_sparse_array_2d_double.cereal";
+    std::string file_name = "test_sparse_array_2d_float.cereal";
     array_to_file(file_name, sparse_array);
-    auto loaded_array = array_from_file<SSparseArrayFloat2d>(file_name);
+    SSparseArrayDouble2dPtr loaded_array = array_from_file<SSparseArrayDouble2d>(file_name);
   } catch (const std::exception &e) {
     caught = true;
   }

--- a/lib/cpp-test/base/utils_gtest.cpp
+++ b/lib/cpp-test/base/utils_gtest.cpp
@@ -305,13 +305,13 @@ TEST(TimeFuncTest, Serialization) {
 
   std::stringstream ss;
   {
-    cereal::JSONOutputArchive outputArchive(ss);
+    cereal::PortableBinaryOutputArchive outputArchive(ss);
 
     outputArchive(tf);
   }
 
   {
-    cereal::JSONInputArchive inputArchive(ss);
+    cereal::PortableBinaryInputArchive inputArchive(ss);
 
     TimeFunction tf_restored(0.0);
     inputArchive(tf_restored);

--- a/lib/cpp-test/hawkes/model/hawkes_models_gtest.cpp
+++ b/lib/cpp-test/hawkes/model/hawkes_models_gtest.cpp
@@ -9,8 +9,7 @@
 #include <gtest/gtest.h>
 #include "tick/hawkes/model/model_hawkes_sumexpkern_loglik_single.h"
 
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
+#include <cereal/archives/portable_binary.hpp>
 #include <cereal/types/unordered_map.hpp>
 #include <fstream>
 
@@ -158,13 +157,13 @@ TEST_F(HawkesModelTest, hawkes_least_squares_serialization) {
 
   std::stringstream os;
   {
-    cereal::JSONOutputArchive outputArchive(os);
+    cereal::PortableBinaryOutputArchive outputArchive(os);
 
     outputArchive(model);
   }
 
   {
-    cereal::JSONInputArchive inputArchive(os);
+    cereal::PortableBinaryInputArchive inputArchive(os);
 
     ModelHawkesExpKernLeastSqSingle restored_model;
     inputArchive(restored_model);
@@ -228,13 +227,13 @@ TEST_F(HawkesModelTest, hawkes_least_squares_sum_exp_serialization) {
 
   std::stringstream os;
   {
-    cereal::JSONOutputArchive outputArchive(os);
+    cereal::PortableBinaryOutputArchive outputArchive(os);
 
     outputArchive(model);
   }
 
   {
-    cereal::JSONInputArchive inputArchive(os);
+    cereal::PortableBinaryInputArchive inputArchive(os);
 
     ModelHawkesSumExpKernLeastSqSingle restored_model;
     inputArchive(restored_model);
@@ -366,13 +365,13 @@ TEST_F(HawkesModelTest, hawkes_least_squares_sum_exp_list_serialization) {
 
   std::stringstream os;
   {
-    cereal::JSONOutputArchive outputArchive(os);
+    cereal::PortableBinaryOutputArchive outputArchive(os);
 
     outputArchive(model);
   }
 
   {
-    cereal::JSONInputArchive inputArchive(os);
+    cereal::PortableBinaryInputArchive inputArchive(os);
 
     ModelHawkesSumExpKernLeastSq restored_model;
     inputArchive(restored_model);

--- a/lib/cpp-test/linear_model/models_gtest.cpp
+++ b/lib/cpp-test/linear_model/models_gtest.cpp
@@ -12,12 +12,10 @@
 #include "tick/array/array.h"
 #include "tick/linear_model/model_linreg.h"
 
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
 #include <cereal/types/memory.hpp>
 #include <cereal/types/unordered_map.hpp>
-
 #include <cereal/archives/portable_binary.hpp>
+
 #include <fstream>
 
 TEST(Model, PartialVsFull) {
@@ -117,10 +115,10 @@ void TestModelLinRegSerialization() {
 
 }  // namespace
 
-TEST(Model, SerializationJSON) {
+TEST(Model, SerializationPortableBinary) {
   SCOPED_TRACE("");
-  ::TestModelLinRegSerialization<cereal::JSONInputArchive,
-                                 cereal::JSONOutputArchive>();
+  ::TestModelLinRegSerialization<cereal::PortableBinaryInputArchive,
+                                 cereal::PortableBinaryOutputArchive>();
 }
 
 TEST(Model, SerializationBinary) {

--- a/lib/cpp-test/serialization/include.h
+++ b/lib/cpp-test/serialization/include.h
@@ -8,8 +8,7 @@
 #define DEBUG_COSTLY_THROW 1
 #define TICK_TEST_DATA_SIZE (1000)
 
-#include <cereal/archives/binary.hpp>
-#include <cereal/archives/json.hpp>
+#include <cereal/archives/portable_binary.hpp>
 #include <cereal/types/memory.hpp>
 #include <cereal/types/unordered_map.hpp>
 
@@ -164,8 +163,8 @@ class Wrapper {
 template <typename T1, typename H1, class SOLVER, class MODEL>
 void do_with(const std::shared_ptr<SOLVER> solver,
              const std::shared_ptr<MODEL> model, const char *label, H1 &&prox) {
-  ::Wrapper<T1, cereal::JSONInputArchive,
-            cereal::JSONOutputArchive>::TestSerializing(solver, model,
+  ::Wrapper<T1, cereal::PortableBinaryInputArchive,
+            cereal::PortableBinaryOutputArchive>::TestSerializing(solver, model,
                                                         std::forward<H1>(prox));
 }
 template <typename T1, typename H1, class SOLVER, class MODEL, typename... T>

--- a/lib/cpp-test/serialization/solver.cpp
+++ b/lib/cpp-test/serialization/solver.cpp
@@ -69,14 +69,14 @@ void test_linear_separable(std::function<std::shared_ptr<MODEL>(
 }
 
 //####################### LIN REG ############################################
-TEST(Model, LinRegDoubleSerializationJSON) {
+TEST(Model, LinRegDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelLinReg<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelLinReg<double> >(features, labels, false,
                                                        1);
       });
 }
-TEST(Model, LinRegFloatSerializationJSON) {
+TEST(Model, LinRegFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelLinReg<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelLinReg<float> >(features, labels, false,
@@ -86,7 +86,7 @@ TEST(Model, LinRegFloatSerializationJSON) {
 //####################### LIN REG ############################################
 
 //####################### LOG REG ############################################
-TEST(Model, LogRegDoubleSerializationJSON) {
+TEST(Model, LogRegDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelLogReg<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelLogReg<double> >(features, labels, false,
@@ -94,7 +94,7 @@ TEST(Model, LogRegDoubleSerializationJSON) {
       });
 }
 
-TEST(Model, LogRegFloatSerializationJSON) {
+TEST(Model, LogRegFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelLogReg<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelLogReg<float> >(features, labels, false,
@@ -104,14 +104,14 @@ TEST(Model, LogRegFloatSerializationJSON) {
 //####################### LOG REG ############################################
 
 //####################### POIS REG ###########################################
-TEST(Model, PoisRegDoubleSerializationJSON) {
+TEST(Model, PoisRegDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelPoisReg<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelPoisReg<double> >(
             features, labels, LinkType::identity, false, 1);
       });
 }
-TEST(Model, PoisRegFloatSerializationJSON) {
+TEST(Model, PoisRegFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelPoisReg<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelPoisReg<float> >(
@@ -121,14 +121,14 @@ TEST(Model, PoisRegFloatSerializationJSON) {
 //####################### POIS REG ###########################################
 
 //####################### QUAD HINGE #########################################
-TEST(Model, QuadHingeDoubleSerializationJSON) {
+TEST(Model, QuadHingeDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelQuadraticHinge<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelQuadraticHinge<double> >(features, labels,
                                                                false);
       });
 }
-TEST(Model, QuadHingeFloatSerializationJSON) {
+TEST(Model, QuadHingeFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelQuadraticHinge<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelQuadraticHinge<float> >(features, labels,
@@ -138,13 +138,13 @@ TEST(Model, QuadHingeFloatSerializationJSON) {
 //####################### QUAD HINGE #########################################
 
 //####################### HINGE ##############################################
-TEST(Model, HingeDoubleSerializationJSON) {
+TEST(Model, HingeDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelHinge<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelHinge<double> >(features, labels, false);
       });
 }
-TEST(Model, HingeFloatSerializationJSON) {
+TEST(Model, HingeFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelHinge<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelHinge<float> >(features, labels, false);
@@ -153,14 +153,14 @@ TEST(Model, HingeFloatSerializationJSON) {
 //####################### HINGE ##############################################
 
 //####################### SMOOTH HINGE #######################################
-TEST(Model, SmoothHingeDoubleSerializationJSON) {
+TEST(Model, SmoothHingeDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelSmoothedHinge<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelSmoothedHinge<double> >(features, labels,
                                                               false);
       });
 }
-TEST(Model, SmoothHingeFloatSerializationJSON) {
+TEST(Model, SmoothHingeFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelSmoothedHinge<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelSmoothedHinge<float> >(features, labels,
@@ -170,14 +170,14 @@ TEST(Model, SmoothHingeFloatSerializationJSON) {
 //####################### SMOOTH HINGE #######################################
 
 //####################### ABSOLUTE REG #######################################
-TEST(Model, AbsoluteRegressionDoubleSerializationJSON) {
+TEST(Model, AbsoluteRegressionDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelAbsoluteRegression<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelAbsoluteRegression<double> >(
             features, labels, false);
       });
 }
-TEST(Model, AbsoluteRegressionFloatSerializationJSON) {
+TEST(Model, AbsoluteRegressionFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelAbsoluteRegression<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelAbsoluteRegression<float> >(
@@ -187,14 +187,14 @@ TEST(Model, AbsoluteRegressionFloatSerializationJSON) {
 //####################### ABSOLUTE REG #######################################
 
 //####################### EPSIL INSENS #######################################
-TEST(Model, EpsilonInsensitiveDoubleSerializationJSON) {
+TEST(Model, EpsilonInsensitiveDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelEpsilonInsensitive<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelEpsilonInsensitive<double> >(
             features, labels, false, 100);
       });
 }
-TEST(Model, EpsilonInsensitiveFloatSerializationJSON) {
+TEST(Model, EpsilonInsensitiveFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelEpsilonInsensitive<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelEpsilonInsensitive<float> >(
@@ -204,14 +204,14 @@ TEST(Model, EpsilonInsensitiveFloatSerializationJSON) {
 //####################### EPSIL INSENS #######################################
 
 //####################### GEN LIN WITH INT ###################################
-TEST(Model, GeneralizedLinearDoubleSerializationJSON) {
+TEST(Model, GeneralizedLinearDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelGeneralizedLinearWithIntercepts<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelGeneralizedLinearWithIntercepts<double> >(
             features, labels, false);
       });
 }
-TEST(Model, GeneralizedLinearSerializationJSON) {
+TEST(Model, GeneralizedLinearSerializationPortableBinary) {
   test_linear_separable<float, TModelGeneralizedLinearWithIntercepts<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelGeneralizedLinearWithIntercepts<float> >(
@@ -221,14 +221,14 @@ TEST(Model, GeneralizedLinearSerializationJSON) {
 //####################### GEN LIN WITH INT ###################################
 
 //####################### HUBER ##############################################
-TEST(Model, HuberDoubleSerializationJSON) {
+TEST(Model, HuberDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelHuber<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelHuber<double> >(features, labels, false,
                                                       100);
       });
 }
-TEST(Model, HuberFloatSerializationJSON) {
+TEST(Model, HuberFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelHuber<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelHuber<float> >(features, labels, false,
@@ -238,14 +238,14 @@ TEST(Model, HuberFloatSerializationJSON) {
 //####################### HUBER ##############################################
 
 //####################### LIN REG INT ########################################
-TEST(Model, LinRegWithInterceptsDoubleSerializationJSON) {
+TEST(Model, LinRegWithInterceptsDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelLinRegWithIntercepts<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelLinRegWithIntercepts<double> >(
             features, labels, false);
       });
 }
-TEST(Model, LinRegWithInterceptsFloatSerializationJSON) {
+TEST(Model, LinRegWithInterceptsFloatSerializationPortableBinary) {
   test_linear_separable<float, TModelLinRegWithIntercepts<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelLinRegWithIntercepts<float> >(
@@ -255,14 +255,14 @@ TEST(Model, LinRegWithInterceptsFloatSerializationJSON) {
 //####################### LIN REG INT ########################################
 
 //####################### MODIFIED HUBER #####################################
-TEST(Model, ModifiedHuberDoubleSerializationJSON) {
+TEST(Model, ModifiedHuberDoubleSerializationPortableBinary) {
   test_linear_separable<double, TModelModifiedHuber<double> >(
       [](const SBaseArrayDouble2dPtr &features, const SArrayDoublePtr &labels) {
         return std::make_shared<TModelModifiedHuber<double> >(features, labels,
                                                               false);
       });
 }
-TEST(Model, ModifiedHuberSerializationJSON) {
+TEST(Model, ModifiedHuberSerializationPortableBinary) {
   test_linear_separable<float, TModelModifiedHuber<float> >(
       [](const SBaseArrayFloat2dPtr &features, const SArrayFloatPtr &labels) {
         return std::make_shared<TModelModifiedHuber<float> >(features, labels,

--- a/lib/cpp-test/solver/saga_gtest.cpp
+++ b/lib/cpp-test/solver/saga_gtest.cpp
@@ -2,7 +2,6 @@
 
 #include <gtest/gtest.h>
 #include <cereal/types/memory.hpp>
-#include <cereal/archives/json.hpp>
 #include <cereal/archives/portable_binary.hpp>
 
 #include "tick/linear_model/model_linreg.h"

--- a/lib/include/tick/array/sparsearray2d.h
+++ b/lib/include/tick/array/sparsearray2d.h
@@ -111,43 +111,20 @@ class SparseArray2d : public BaseArray2d<T> {
 
   // Atomic data, BinaryInputArchive
   template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, std::atomic<K>>::value
-    && cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
+  typename std::enable_if<std::is_same<Y, std::atomic<K>>::value>::type
   inner_save(Archive &ar) const {
     for (size_t i = 0; i < this->_size_sparse; i++) ar(this->_data[i].load());
     ar(cereal::binary_data(this->_indices, sizeof(INDICE_TYPE) * this->_size_sparse));
     ar(cereal::binary_data(this->_row_indices, sizeof(INDICE_TYPE) * (this->_n_rows + 1)));
-  }
-
-  // This is for JSON types that are used in pickling, TODO: try make pickly use only binary types
-  // Atomic data, NonBinaryInputArchive
-  template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, std::atomic<K>>::value
-    && !cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
-  inner_save(Archive &ar) const {
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(this->_data[i].load());
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(this->_indices[i]);
-    for (size_t i = 0; i < this->_n_rows + 1; i++) ar(this->_row_indices[i]);
   }
 
   // Non-atomic data, BinaryInputArchive
   template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, K>::value
-    && cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
+  typename std::enable_if<std::is_same<Y, K>::value>::type
   inner_save(Archive &ar) const {
     ar(cereal::binary_data(this->_data, sizeof(T) * this->_size_sparse));
     ar(cereal::binary_data(this->_indices, sizeof(INDICE_TYPE) * this->_size_sparse));
     ar(cereal::binary_data(this->_row_indices, sizeof(INDICE_TYPE) * (this->_n_rows + 1)));
-  }
-
-  // Non-atomic data, NonBinaryInputArchive
-  template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, K>::value
-    && !cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
-  inner_save(Archive &ar) const {
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(this->_data[i]);
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(this->_indices[i]);
-    for (size_t i = 0; i < this->_n_rows + 1; i++) ar(this->_row_indices[i]);
   }
 
   template <class Archive>
@@ -186,8 +163,7 @@ class SparseArray2d : public BaseArray2d<T> {
 
   // Atomic data, BinaryInputArchive
   template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, std::atomic<K>>::value
-    && cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
+  typename std::enable_if<std::is_same<Y, std::atomic<K>>::value>::type
   inner_load(Archive &ar, T *s_data, INDICE_TYPE *s_indices, INDICE_TYPE *s_row_indices) {
     K data;
     for (size_t i = 0; i < this->_size_sparse; i++) {
@@ -196,40 +172,15 @@ class SparseArray2d : public BaseArray2d<T> {
     }
     ar(cereal::binary_data(s_indices, sizeof(INDICE_TYPE) * this->_size_sparse));
     ar(cereal::binary_data(s_row_indices, sizeof(INDICE_TYPE) * (this->_n_rows + 1)));
-  }
-
-  // Atomic data, NonBinaryInputArchive
-  template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, std::atomic<K>>::value
-    && !cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
-  inner_load(Archive &ar, T *s_data, INDICE_TYPE *s_indices, INDICE_TYPE *s_row_indices) {
-    K data;
-    for (size_t i = 0; i < this->_size_sparse; i++) {
-      ar(data);
-      s_data[i].store(data);
-    }
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(s_indices[i]);
-    for (size_t i = 0; i < this->_n_rows + 1; i++) ar(s_row_indices[i]);
   }
 
   // Non-atomic data, BinaryInputArchive
   template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, K>::value
-    && cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
+  typename std::enable_if<std::is_same<Y, K>::value>::type
   inner_load(Archive &ar, T *s_data, INDICE_TYPE *s_indices, INDICE_TYPE *s_row_indices) {
     ar(cereal::binary_data(s_data, sizeof(T) * this->_size_sparse));
     ar(cereal::binary_data(s_indices, sizeof(INDICE_TYPE) * this->_size_sparse));
     ar(cereal::binary_data(s_row_indices, sizeof(INDICE_TYPE) * (this->_n_rows + 1)));
-  }
-
-  // Non-atomic data, NonBinaryInputArchive
-  template <class Archive, typename Y = T>
-  typename std::enable_if<std::is_same<Y, K>::value
-    && !cereal::traits::is_output_serializable<cereal::BinaryData<T>, Archive>::value, void>::type
-  inner_load(Archive &ar, T *s_data, INDICE_TYPE *s_indices, INDICE_TYPE *s_row_indices) {
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(s_data[i]);
-    for (size_t i = 0; i < this->_size_sparse; i++) ar(s_indices[i]);
-    for (size_t i = 0; i < this->_n_rows + 1; i++) ar(s_row_indices[i]);
   }
 };
 

--- a/lib/include/tick/base/serialization.h
+++ b/lib/include/tick/base/serialization.h
@@ -18,7 +18,8 @@ DISABLE_WARNING(unused, exceptions, 42)
 DISABLE_WARNING(unused, unused-private-field, 42)
 DISABLE_WARNING(delete-non-virtual-dtor, delete-non-virtual-dtor, 42)
 #endif
-#include "cereal/archives/json.hpp"
+#include "cereal/archives/portable_binary.hpp"
+#include <iomanip>
 #ifndef TICK_SWIG_INCLUDE
 ENABLE_WARNING(unused, exceptions, 42)
 ENABLE_WARNING(unused, unused-private-field, 42)
@@ -27,28 +28,45 @@ ENABLE_WARNING(delete-non-virtual-dtor, delete-non-virtual-dtor, 42)
 // clang-format on
 // Carry on formatting
 
+
+// Turn serialzed PortableBinary bytes into hex
 namespace tick {
+
+inline std::string to_hex(const std::string &bytes) {
+  std::stringstream out;
+  for (const char &c : bytes) {
+    std::stringstream stream;
+    stream << std::setfill('0')<< std::setw(2) << std::hex << static_cast<unsigned int>(c);
+    out << stream.str() << " ";  // parsing back hex to binary requires spaces for some reason
+  }
+  return out.str();
+}
 
 template <typename T>
 inline std::string object_to_string(T* ptr) {
-  std::ostringstream ss(std::ios::binary);
-
+  std::ostringstream ss(std::ios::out | std::ios::binary);
   {
-    cereal::JSONOutputArchive ar(ss);
+    cereal::PortableBinaryOutputArchive ar(ss);
     ar(*ptr);
   }
-
-  return ss.str();
+  return to_hex(ss.str());
 }
 
-template <typename T>
-inline void object_from_string(T* ptr, const std::string& data) {
-  std::istringstream ss(data, std::ios::binary);
+inline std::string to_bytes(const std::string &hex) {
+  std::istringstream hex_chars_stream(hex);
+  std::vector<unsigned char> bytes;
+  unsigned int c;
+  while (hex_chars_stream >> std::hex >> std::setw(2) >> c) bytes.push_back(c);
+  return std::string(bytes.begin(), bytes.end());
+}
 
-  cereal::JSONInputArchive ar(ss);
+// Convert hex into bytes to deserialize
+template <typename T>
+inline void object_from_string(T* ptr, const std::string& hex) {
+  std::istringstream ss(to_bytes(hex));
+  cereal::PortableBinaryInputArchive ar(ss);
   ar(*ptr);
 }
-
 }  // namespace tick
 
 #endif  // LIB_INCLUDE_TICK_BASE_SERIALIZATION_H_


### PR DESCRIPTION
We replace the "JSON" Input/Output archives with hexed "PortableBinary"

Hexed because Python can't seem to tolerate strings containing bytes

Should be smaller too