### PR TITLE
dropping 3.7 on CI until more mature 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,23 +17,25 @@ matrix:
     env:
       - DOCKER_IMAGE=xdatainitiative/tick_ubuntu:1.4.2
       - PYVER=3.6.1
-  - os: linux
-    services: docker
-    env:
-      - DOCKER_IMAGE=xdatainitiative/tick_ubuntu:1.4.2
-      - PYVER=3.7.0
+  ## 3.7 is dropped until more mature
+  # - os: linux
+  #   services: docker
+  #   env:
+  #     - DOCKER_IMAGE=xdatainitiative/tick_ubuntu:1.4.2
+  #     - PYVER=3.7.0
   - os: osx
     language: generic
     sudo: required
     env:
       - PYVER=3.6.1
     osx_image: xcode9.1
-  - os: osx
-    language: generic
-    sudo: required
-    env:
-      - PYVER=3.7.0
-    osx_image: xcode9.1
+  ## 3.7 is dropped until more mature
+  # - os: osx
+  #   language: generic
+  #   sudo: required
+  #   env:
+  #     - PYVER=3.7.0
+  #   osx_image: xcode9.1
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB; fi


### PR DESCRIPTION
i.e. tensorflow release for 3.7 exists