### PR TITLE
import order for libraries loading in correct order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ matrix:
   #   osx_image: xcode9.1
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get stable; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get "stable"; fi
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source tools/travis/osx_install.sh; fi

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -47,9 +47,9 @@ model with several choices of penalizations and solvers.
    :toctree: generated/
    :template: class.rst
 
-   linear_model.LinearRegression
-   linear_model.LogisticRegression
-   linear_model.PoissonRegression
+   linear_model.linear_regression import LinearRegression
+   linear_model.logistic_regression import LogisticRegression
+   linear_model.poisson_regression import PoissonRegression
 
 These classes follow whenever possible the scikit-learn API, namely ``fit``
 and ``predict`` methods, and follow the same naming conventions.

--- a/examples/plot_2d_linear_regression.py
+++ b/examples/plot_2d_linear_regression.py
@@ -22,6 +22,7 @@ This example is inspired by linear regression example from
 import matplotlib.pyplot as plt
 import numpy as np
 from tick import linear_model
+from tick.linear_model.linear_regression import LinearRegression
 from sklearn.metrics import mean_squared_error, r2_score
 from sklearn.utils import shuffle
 from sklearn.datasets import load_boston
@@ -46,7 +47,7 @@ y_train = label[:n_train_data]
 y_test = label[n_train_data:]
 
 # Create linear regression and fit it on the training set
-regr = linear_model.LinearRegression()
+regr = LinearRegression()
 regr.fit(X_train, y_train)
 
 # Make predictions using the testing set

--- a/examples/plot_conv_sccs_cv_results.py
+++ b/examples/plot_conv_sccs_cv_results.py
@@ -13,8 +13,8 @@ import numpy as np
 from scipy.sparse import csr_matrix, hstack
 from matplotlib import cm
 import matplotlib.pylab as plt
-from tick.survival.simu_sccs import CustomEffects
 from tick.survival import SimuSCCS, ConvSCCS
+from tick.survival.simu_sccs import CustomEffects
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 # Simulation parameters

--- a/examples/plot_logistic_adult.py
+++ b/examples/plot_logistic_adult.py
@@ -10,8 +10,8 @@ regression learner (`tick.inference.LogisticRegression`).
 import matplotlib.pyplot as plt
 from sklearn.metrics import roc_curve, auc
 
-from tick.linear_model import LogisticRegression
 from tick.dataset import fetch_tick_dataset
+from tick.linear_model.logistic_regression import LogisticRegression
 
 train_set = fetch_tick_dataset('binary/adult/adult.trn.bz2')
 test_set = fetch_tick_dataset('binary/adult/adult.tst.bz2')

--- a/examples/plot_logistic_tick_vs_scikit.py
+++ b/examples/plot_logistic_tick_vs_scikit.py
@@ -29,7 +29,7 @@ from sklearn.metrics import roc_curve, auc
 from sklearn.linear_model import LogisticRegression as LogRegScikit
 
 from tick.dataset import fetch_tick_dataset
-from tick.linear_model import LogisticRegression as LogRegTick
+from tick.linear_model.logistic_regression import LogisticRegression as LogRegTick
 
 train_set = fetch_tick_dataset('binary/adult/adult.trn.bz2')
 test_set = fetch_tick_dataset('binary/adult/adult.tst.bz2')

--- a/examples/plot_low_precision_learner.py
+++ b/examples/plot_low_precision_learner.py
@@ -15,8 +15,8 @@ float 32 precision.
 import matplotlib.pyplot as plt
 
 from tick.dataset import fetch_tick_dataset
-from tick.linear_model import LogisticRegression
 from tick.plot import plot_history
+from tick.linear_model.logistic_regression import LogisticRegression
 
 X, y = fetch_tick_dataset('binary/adult/adult.trn.bz2')
 X = X.toarray()  # It is more visible with dense matrices

--- a/examples/plot_poisson_regression.py
+++ b/examples/plot_poisson_regression.py
@@ -34,8 +34,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from tick.simulation import weights_sparse_gauss
-from tick.linear_model import SimuPoisReg, PoissonRegression
+from tick.linear_model import SimuPoisReg
 from tick.plot import plot_history
+from tick.linear_model.poisson_regression import PoissonRegression
 
 n_samples = 50000
 n_features = 100

--- a/examples/plot_robust_linear_regression.py
+++ b/examples/plot_robust_linear_regression.py
@@ -26,8 +26,9 @@ import numpy as np
 from matplotlib import pyplot as plt
 from tick.simulation import weights_sparse_gauss, \
     features_normal_cov_toeplitz
-from tick.robust import RobustLinearRegression, std_iqr
 from tick.metrics import support_fdp, support_recall
+from tick.robust import std_iqr
+from tick.robust.robust_linear_regression import RobustLinearRegression
 
 np.random.seed(1)
 

--- a/tick/base/__init__.py
+++ b/tick/base/__init__.py
@@ -21,9 +21,9 @@ def _set_mpl_backend():
 _set_mpl_backend()
 
 from tick.array import *
-from ..random import *
 from .timefunc import TimeFunction
 from .base import Base
+from ..random import *
 from .decorators import actual_kwargs
 from .threadpool import ThreadPool
 

--- a/tick/hawkes/model/__init__.py
+++ b/tick/hawkes/model/__init__.py
@@ -1,5 +1,6 @@
 # License: BSD 3 clause
 
+import tick.base_model.build.base_model
 from .model_hawkes_expkern_leastsq import ModelHawkesExpKernLeastSq
 from .model_hawkes_expkern_loglik import ModelHawkesExpKernLogLik
 from .model_hawkes_sumexpkern_leastsq import ModelHawkesSumExpKernLeastSq

--- a/tick/linear_model/__init__.py
+++ b/tick/linear_model/__init__.py
@@ -2,10 +2,6 @@
 
 import tick.base
 
-from .linear_regression import LinearRegression
-from .logistic_regression import LogisticRegression
-from .poisson_regression import PoissonRegression
-
 from .model_linreg import ModelLinReg
 from .model_logreg import ModelLogReg
 from .model_hinge import ModelHinge
@@ -18,7 +14,6 @@ from .simu_logreg import SimuLogReg
 from .simu_poisreg import SimuPoisReg
 
 __all__ = [
-    'LinearRegression', 'LogisticRegression', 'LogisticRegression',
     'ModelLinReg', 'ModelLogReg', 'ModelPoisReg', 'ModelHinge',
     'ModelSmoothedHinge', 'ModelQuadraticHinge', 'SimuLinReg', 'SimuLogReg',
     'SimuPoisReg'

--- a/tick/linear_model/__init__.py
+++ b/tick/linear_model/__init__.py
@@ -1,6 +1,7 @@
 # License: BSD 3 clause
 
 import tick.base
+import tick.base_model.build.base_model
 
 from .model_linreg import ModelLinReg
 from .model_logreg import ModelLogReg

--- a/tick/linear_model/tests/linear_regression_test.py
+++ b/tick/linear_model/tests/linear_regression_test.py
@@ -8,9 +8,10 @@ import numpy as np
 from scipy.linalg import norm
 
 from tick.base.inference import InferenceTest
-from tick.linear_model import SimuLinReg, LinearRegression
+from tick.linear_model import SimuLinReg
 from tick.simulation import weights_sparse_gauss
 
+from tick.linear_model.linear_regression import LinearRegression
 
 class Test(InferenceTest):
     def setUp(self):

--- a/tick/linear_model/tests/logistic_regression_test.py
+++ b/tick/linear_model/tests/logistic_regression_test.py
@@ -7,12 +7,14 @@ import numpy as np
 from sklearn.metrics.ranking import roc_auc_score
 
 from tick.base.inference import InferenceTest
-from tick.linear_model import SimuLogReg, LogisticRegression
+from tick.linear_model import SimuLogReg
 from tick.simulation import weights_sparse_gauss
 from tick.preprocessing.features_binarizer import FeaturesBinarizer
 from tick.prox import ProxZero, ProxL1, ProxL2Sq, ProxElasticNet, ProxTV, \
     ProxBinarsity
+
 from tick.solver import AGD, GD, BFGS, SGD, SVRG, SDCA
+from tick.linear_model.logistic_regression import LogisticRegression
 
 solvers = ['gd', 'agd', 'sgd', 'sdca', 'bfgs', 'svrg']
 penalties = ['none', 'l2', 'l1', 'tv', 'elasticnet', 'binarsity']

--- a/tick/linear_model/tests/poisson_regression_test.py
+++ b/tick/linear_model/tests/poisson_regression_test.py
@@ -6,9 +6,10 @@ from itertools import product
 import numpy as np
 
 from tick.base.inference import InferenceTest
-from tick.linear_model import SimuPoisReg, PoissonRegression
+from tick.linear_model import SimuPoisReg
 from tick.simulation import weights_sparse_gauss
 
+from tick.linear_model.poisson_regression import PoissonRegression
 
 class Test(InferenceTest):
     def setUp(self):

--- a/tick/plot/tests/plot_history_test.py
+++ b/tick/plot/tests/plot_history_test.py
@@ -4,9 +4,9 @@ import unittest
 
 import numpy as np
 
-from tick.linear_model import LogisticRegression
 from tick.plot import plot_history
 from tick.solver import GD, AGD, History
+from tick.linear_model.logistic_regression import LogisticRegression
 
 
 class Test(unittest.TestCase):

--- a/tick/robust/__init__.py
+++ b/tick/robust/__init__.py
@@ -1,6 +1,8 @@
 # License: BSD 3 clause
 
-
+import tick.base
+import tick.base_model.build.base_model
+import tick.linear_model.build.linear_model
 from .robust import std_iqr, std_mad
 
 from .model_epsilon_insensitive import ModelEpsilonInsensitive

--- a/tick/robust/__init__.py
+++ b/tick/robust/__init__.py
@@ -1,17 +1,14 @@
 # License: BSD 3 clause
 
-from .robust_linear_regression import RobustLinearRegression
 
 from .robust import std_iqr, std_mad
 
-from .model_absolute_regression import ModelAbsoluteRegression
 from .model_epsilon_insensitive import ModelEpsilonInsensitive
 from .model_huber import ModelHuber
 from .model_linreg_with_intercepts import ModelLinRegWithIntercepts
 from .model_modified_huber import ModelModifiedHuber
 
 __all__ = [
-    'RobustLinearRegression', 'std_iqr', 'std_mad',
-    'ModelLinRegWithIntercepts', 'ModelHuber', 'ModelModifiedHuber',
-    'ModelEpsilonInsensitive', 'ModelAbsoluteRegression'
+    'std_iqr', 'std_mad', 'ModelLinRegWithIntercepts', 'ModelHuber',
+    'ModelModifiedHuber', 'ModelEpsilonInsensitive',
 ]

--- a/tick/robust/base/__init__.py
+++ b/tick/robust/base/__init__.py
@@ -1,5 +1,4 @@
 # License: BSD 3 clause
 
-from .learner_robust_glm import LearnerRobustGLM
 from .model_generalized_linear_with_intercepts import \
     ModelGeneralizedLinearWithIntercepts

--- a/tick/robust/robust_linear_regression.py
+++ b/tick/robust/robust_linear_regression.py
@@ -1,9 +1,8 @@
 # License: BSD 3 clause
 
 from tick.base import actual_kwargs
-from .base import LearnerRobustGLM
 from .model_linreg_with_intercepts import ModelLinRegWithIntercepts
-
+from .base.learner_robust_glm import LearnerRobustGLM
 
 class RobustLinearRegression(LearnerRobustGLM):
     """Robust linear regression learner.

--- a/tick/robust/tests/model_absolute_regression_test.py
+++ b/tick/robust/tests/model_absolute_regression_test.py
@@ -5,10 +5,9 @@ import unittest
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from tick.robust import ModelAbsoluteRegression
 from tick.base_model.tests.generalized_linear_model import TestGLM
 from tick.linear_model import SimuLinReg
-
+from tick.robust.model_absolute_regression import ModelAbsoluteRegression
 
 class Test(TestGLM):
     def test_ModelAbsoluteRegression(self):

--- a/tick/robust/tests/robust_linear_regression_test.py
+++ b/tick/robust/tests/robust_linear_regression_test.py
@@ -6,10 +6,10 @@ import unittest
 import numpy as np
 
 from tick.base.inference import InferenceTest
-from tick.robust import RobustLinearRegression
 from tick.simulation import weights_sparse_gauss, features_normal_cov_toeplitz
 from tick.metrics import support_fdp, support_recall
 
+from tick.robust.robust_linear_regression import RobustLinearRegression
 
 class Test(InferenceTest):
     n_samples = 300

--- a/tick/robust/tests/serializing_test.py
+++ b/tick/robust/tests/serializing_test.py
@@ -14,8 +14,9 @@ from tick.linear_model import ModelLogReg, SimuLogReg
 from tick.linear_model import ModelPoisReg, SimuPoisReg
 from tick.linear_model import ModelHinge, ModelQuadraticHinge, ModelSmoothedHinge
 
-from tick.robust import ModelAbsoluteRegression, ModelEpsilonInsensitive, ModelHuber, \
+from tick.robust import ModelEpsilonInsensitive, ModelHuber, \
                         ModelLinRegWithIntercepts, ModelModifiedHuber
+from tick.robust.model_absolute_regression import ModelAbsoluteRegression
 
 from tick.simulation import weights_sparse_gauss
 

--- a/tick/solver/__init__.py
+++ b/tick/solver/__init__.py
@@ -1,6 +1,9 @@
 # License: BSD 3 clause
 
 import tick.base
+import tick.base_model.build.base_model
+import tick.linear_model.build.linear_model
+import tick.robust.build.robust
 
 from .gd import GD
 from .agd import AGD

--- a/tick/solver/tests/serializing_test.py
+++ b/tick/solver/tests/serializing_test.py
@@ -15,8 +15,10 @@ from tick.linear_model import ModelLogReg, SimuLogReg
 from tick.linear_model import ModelPoisReg, SimuPoisReg
 from tick.linear_model import ModelHinge, ModelQuadraticHinge, ModelSmoothedHinge
 
-from tick.robust import ModelAbsoluteRegression, ModelEpsilonInsensitive, ModelHuber, \
+from tick.robust import ModelEpsilonInsensitive, ModelHuber, \
                         ModelLinRegWithIntercepts, ModelModifiedHuber
+from tick.robust.model_absolute_regression import ModelAbsoluteRegression
+
 from tick.solver import AdaGrad, SGD, SDCA, SAGA, SVRG
 from tick.simulation import weights_sparse_gauss
 

--- a/tick/survival/__init__.py
+++ b/tick/survival/__init__.py
@@ -1,6 +1,7 @@
 # License: BSD 3 clause
 
 import tick.base
+import tick.base_model.build.base_model
 
 from .cox_regression import CoxRegression
 


### PR DESCRIPTION
In newer versions of python on Ubuntu/Debian

The ordering of imports is causing issues and throwing "library not found" errors. Shows up on WSL too https://github.com/X-DataInitiative/tick/issues/361

This is in part due to the order of imports, and the location of "Regression" and "Learner" type files which use solver classes before they really imported.

The solution here is to remove "Regression" and "Learner" imports from the "__init__.py" files and use the full import path when needed

another solution would be to have Learner/Regression classes above Solver in the hierarchy and isolated in their own module