### PR TITLE
Block "pytest" Windows - add "stdlib.h"

### DIFF
--- a/lib/include/tick/base/interruption.h
+++ b/lib/include/tick/base/interruption.h
@@ -13,8 +13,9 @@
 
 #include "defs.h"
 
-#include <atomic>
+#include <stdlib.h>  // for the "exit" function
 #include <exception>
+#include <atomic>
 
 /*! \class Interruption
  * \brief Exception Class made to handle Ctrl-C interruption

--- a/setup.py
+++ b/setup.py
@@ -824,6 +824,11 @@ class RunPyTests(TickCommand):
         self.start_dir = '.'
 
     def run(self):
+        if platform.system() == 'Windows':
+            print("The pytest command has issues with threads on Windows")
+            print('Instead please run:')
+            print('python3 -m unittest discover -v . "*_test.py"')
+            exit(1)
         loader = unittest.TestLoader()
         alltests = loader.discover(self.start_dir, pattern="*_test.py")
         result = unittest.TextTestRunner(verbosity=2).run(alltests)


### PR DESCRIPTION
    Block the command "pytest" from setup.py on Windows as it has issues finishing (it doesn't)

    Add "stdlib.h" for the "exit" function which is needed for some distros

solves https://github.com/X-DataInitiative/tick/issues/359
and https://github.com/X-DataInitiative/tick/issues/362