### PR TITLE
load dep libs if not loaded

### DIFF
--- a/tick/survival/__init__.py
+++ b/tick/survival/__init__.py
@@ -1,6 +1,7 @@
 # License: BSD 3 clause
 
 import tick.base
+import tick.base_model.build.base_model
 
 from .cox_regression import CoxRegression
 


### PR DESCRIPTION
if built from python setup.py and if the first import is "tick.survival" it will fail