### PR TITLE
#438 track intensity contributions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -111,15 +111,20 @@ This will build all required C++ extensions, and install the extensions in your 
 
     ./tools/windows/install.sh
 
-#### In-place installation (for developers)
+### In-place installation (for developers)
 
-If you wish to work with the source code of _tick_ it's convenient to have the extensions installed inside the source directory. This way you will not have to install the module for each iteration of the code. Simply do:
+If you wish to work with the source code of _tick_ it's convenient to have the extensions installed inside the source directory. This way you will not have to install the module for each iteration of the code. After initialising the submodules simply do:
 
     python setup.py build_ext --inplace
 
 This will build all extensions, and install them directly in the source directory. To use the package outside of the build directory, the build path should be added to the `PYTHONPATH` environment variable (replace `$PWD` with the full path to the build directory if necessary):
 
     export PYTHONPATH=$PYTHONPATH:$PWD
+
+To speed up repeated compilation times you might wish to use [ccache](https://ccache.dev/). ccache is a third party tool which may have to be installed manually on your system. ccache does not work on Windows.
+To use ccache with tick do:
+
+    CC="ccache g++" python3 setup.py build_ext --inplace
 
 Note also that special scripts, intended for developers, are available. `./clean_build_test.sh` removes all compiled binaries and runs the full compilation process, with all `C++` and `Python` unit-tests. This can take some time.
 Similarly, `./build_test.sh` runs the full compilation process, without removing first binaries, while `full_clean.sh` only removes them.
@@ -149,7 +154,7 @@ As with tick in general, this requires python3 and all python pre-requisites. nu
 
 This method is provided mainly for developers to decrease compilation times.
 
-To use [ccache](https://ccache.samba.org/) (or similar) with mkn, edit your ~/.maiken/settings.yaml file so it looks like one [here](https://github.com/Dekken/maiken/wiki/Alternative-configs) - this can greatly decrease repeated compilation times. ccache is a third party tool which may have to be installed manually on your system. ccache does not work on Windows.
+To use [ccache](https://ccache.samba.org/) (or similar) with mkn, edit your ~/.maiken/settings.yaml file so it looks like one [here](https://github.com/Dekken/maiken/wiki/Alternative-configs)
 
 On windows it may be required to configure the maiken settings.yaml manually if the environment variables exported by the Visual Studio batch file "vcvars" are not found, example configurations can be found [here](https://github.com/Dekken/maiken/wiki)
 

--- a/doc/modules/dev.rst
+++ b/doc/modules/dev.rst
@@ -207,7 +207,7 @@ value of the C++ int.
 
 .. note::
     If the reader wants to run this example, he might find the corresponding
-    class by importing it `from tick.base.utils.build.utils import A0 as _A`.
+    class by importing it `from tick.base.build.base import A0 as _A`.
 
 How does this work?
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/cpp/hawkes/simulation/simu_hawkes.cpp
+++ b/lib/cpp/hawkes/simulation/simu_hawkes.cpp
@@ -22,6 +22,16 @@ void Hawkes::init_intensity_(ArrayDouble &intensity,
   }
 }
 
+void Hawkes::init_intensity_contributions_(ArrayDoubleList1D &intensity_contributions) {
+  for (unsigned int i = 0; i < n_nodes; i++) {
+    intensity_contributions[i][0] = get_baseline(i, 0.);
+    for (unsigned int j = 0; j < n_nodes; j++) {
+        intensity_contributions[i][j+1] = 0;
+        }
+    }
+}
+
+
 bool Hawkes::update_time_shift_(double delay, ArrayDouble &intensity,
                                 double *total_intensity_bound1) {
   if (total_intensity_bound1) *total_intensity_bound1 = 0;
@@ -51,6 +61,20 @@ bool Hawkes::update_time_shift_(double delay, ArrayDouble &intensity,
     }
   }
   return flag_negative_intensity1;
+}
+
+void Hawkes::update_time_shift_contributions_(double delay, ArrayDoubleList1D &intensity_contributions) {
+  // We loop on the contributions
+  for (unsigned int i = 0; i < n_nodes; i++) {
+    intensity_contributions[i][0] = get_baseline(i, get_time());
+
+    for (unsigned int j = 0; j < n_nodes; j++) {
+        HawkesKernelPtr &k = kernels[i * n_nodes + j];
+        if (k->get_support() == 0) continue;
+        intensity_contributions[i][j+1] =
+          k->get_convolution(get_time() + delay, *timestamps[j], 0);
+    }
+  }
 }
 
 void Hawkes::reset() {

--- a/lib/cpp/hawkes/simulation/simu_point_process.cpp
+++ b/lib/cpp/hawkes/simulation/simu_point_process.cpp
@@ -65,19 +65,35 @@ void PP::activate_itr(double dt) {
     return;
   }
   if (itr.size() != 0) itr.resize(0);
-
-  itr_time_step = dt;
   itr.resize(n_nodes);
-  for (unsigned int i = 0; i < n_nodes; i++) itr[i] = VArrayDouble::new_ptr();
+  itr_time_step = dt;
+
+  intensity_contributions = ArrayDoubleList1D(n_nodes);
+  itr_contributions.resize(n_nodes);
+
+  for (unsigned int i = 0; i < n_nodes; i++) {
+    itr[i] = VArrayDouble::new_ptr();
+
+    intensity_contributions[i] = ArrayDouble(n_nodes+1);
+    intensity_contributions[i].init_to_zero();
+
+    itr_contributions[i].resize(n_nodes+1);
+    for (unsigned int j = 0; j < n_nodes+1; j++) itr_contributions[i][j] = VArrayDouble::new_ptr();
+  }
   itr_times = VArrayDouble::new_ptr();
+  init_intensity_contributions_(intensity_contributions);
 }
 
 void PP::reseed_random_generator(int seed) { rand.reseed(seed); }
 
 void PP::itr_process() {
   if (!itr_on()) return;
-
-  for (unsigned int i = 0; i < n_nodes; i++) itr[i]->append1(intensity[i]);
+  for (unsigned int i = 0; i < n_nodes; i++) {
+    itr[i]->append1(intensity[i]);
+    for (unsigned int j = 0; j < n_nodes+1; j++) {
+      itr_contributions[i][j]->append1(intensity_contributions[i][j]);
+    }
+  }
   itr_times->append1(time);
 }
 
@@ -86,7 +102,7 @@ void PP::update_time_shift(double delay, bool flag_compute_intensity_bound,
   flag_negative_intensity = update_time_shift_(
       delay, intensity,
       (flag_compute_intensity_bound ? &total_intensity_bound : nullptr));
-
+  if (itr_on()) update_time_shift_contributions_(delay, intensity_contributions);
   time += delay;
 
   if (flag_compute_intensity_bound &&

--- a/lib/include/tick/hawkes/simulation/simu_hawkes.h
+++ b/lib/include/tick/hawkes/simulation/simu_hawkes.h
@@ -132,6 +132,13 @@ class DLL_PUBLIC Hawkes : public PP {
                                double *total_intensity_bound);
 
   /**
+   * @brief Virtual method called once (at startup) to set the initial
+   * intensity contributions
+   * \param intensity_contributions : The intensity matrix (of size #dimension,#dimension+1) to initialize
+   */
+  virtual void init_intensity_contributions_(ArrayDoubleList1D &intensity_contributions);
+
+  /**
    * @brief Updates the current time so that it goes forward of delay seconds
    * The intensities must be updated and track recorded if needed
    * Returns false if negative intensities were encountered
@@ -142,6 +149,13 @@ class DLL_PUBLIC Hawkes : public PP {
    */
   virtual bool update_time_shift_(double delay, ArrayDouble &intensity,
                                   double *total_intensity_bound);
+
+  /**
+   * @brief Updates the intensity contributions matrix
+   * \param delay : Time to update
+   * \param intensity : The intensity_contributions matrix to update
+   */
+  virtual void update_time_shift_contributions_(double delay, ArrayDoubleList1D &intensity_contributions);
 
   /**
    * @brief Get future baseline maximum reachable value for a specific dimension

--- a/lib/include/tick/hawkes/simulation/simu_point_process.h
+++ b/lib/include/tick/hawkes/simulation/simu_point_process.h
@@ -51,6 +51,9 @@ class DLL_PUBLIC PP {
   // Current Intensity of each component
   ArrayDouble intensity;
 
+    // Current Intensity of each component per node
+  ArrayDoubleList1D intensity_contributions;
+
   // Called to init the intensities at start
   void init_intensity();
 
@@ -75,6 +78,9 @@ class DLL_PUBLIC PP {
 
   // The track records of the intensity
   VArrayDoublePtrList1D itr;
+
+  // The track records of the intensity contributions
+  VArrayDoublePtrList2D itr_contributions;
 
   // The time corresponding to the track records of the intensity
   VArrayDoublePtr itr_times;
@@ -162,6 +168,15 @@ class DLL_PUBLIC PP {
     return false;
   }
 
+    /**
+   * @brief Updates the intensity contributions
+   * \param delay : Time to update
+   * \param intensity : The intensity_contributions matrix to update
+   */
+  virtual void update_time_shift_contributions_(double delay, ArrayDoubleList1D &intensity_contributions) {
+    return;
+  }
+
   /**
    * @brief Record a jump in ith component
    */
@@ -191,6 +206,15 @@ class DLL_PUBLIC PP {
    */
   virtual void init_intensity_(ArrayDouble &intensity,
                                double *total_intensity_bound);
+  /**
+   * @brief Virtual method called once (at startup) to set the initial
+   * intensity contributions
+   * \param intensity_contributions : The intensity matrix (of size #dimension,
+   * #dimension+1) to initialize
+   */
+  virtual void init_intensity_contributions_(ArrayDoubleList1D &intensity_contributions) {
+    return;
+  }
 
   ////////////////////////////////////////////////////////////////////////////////
   //                            Getters and setters
@@ -215,6 +239,14 @@ class DLL_PUBLIC PP {
       TICK_ERROR("``activate_itr()`` must be call before simulation");
 
     return itr;
+  }
+
+  /// @brief Returns intensity track contributions record array
+  inline VArrayDoublePtrList2D get_itr_contributions() {
+    if (!itr_on())
+      TICK_ERROR("``activate_itr()`` must be call before simulation");
+
+    return itr_contributions;
   }
 
   /// @brief Returns times at which intensity has been recorded
@@ -272,6 +304,7 @@ class DLL_PUBLIC PP {
     ar(CEREAL_NVP(itr_time));
     ar(CEREAL_NVP(itr_time_step));
     ar(CEREAL_NVP(itr));
+    ar(CEREAL_NVP(itr_contributions));
     ar(CEREAL_NVP(itr_times));
 
     int rand_seed;
@@ -295,6 +328,7 @@ class DLL_PUBLIC PP {
     ar(CEREAL_NVP(itr_time));
     ar(CEREAL_NVP(itr_time_step));
     ar(CEREAL_NVP(itr));
+    ar(CEREAL_NVP(itr_contributions));
     ar(CEREAL_NVP(itr_times));
 
     // Note that only the seed is part of the serialization.

--- a/lib/swig/tick/hawkes/simulation/simu_point_process.i
+++ b/lib/swig/tick/hawkes/simulation/simu_point_process.i
@@ -25,6 +25,7 @@ class PP {
   int get_seed() const;
   ulong get_n_total_jumps();
   VArrayDoublePtrList1D get_itr();
+  VArrayDoublePtrList2D get_itr_contributions();
   VArrayDoublePtr get_itr_times();
   double get_itr_step();
 

--- a/tick/hawkes/simulation/base/simu_point_process.py
+++ b/tick/hawkes/simulation/base/simu_point_process.py
@@ -111,6 +111,13 @@ class SimuPointProcess(Simu):
         return self._pp.get_itr()
 
     @property
+    def tracked_intensity_contributions(self):
+        if not self.is_intensity_tracked():
+            raise ValueError("Intensity has not been tracked, you should call "
+                             "track_intensity before simulation")
+        return self._pp.get_itr_contributions()
+
+    @property
     def intensity_tracked_times(self):
         if not self.is_intensity_tracked():
             raise ValueError("Intensity has not been tracked, you should call "

--- a/tick/hawkes/simulation/tests/simu_hawkes_test.py
+++ b/tick/hawkes/simulation/tests/simu_hawkes_test.py
@@ -253,6 +253,25 @@ class Test(unittest.TestCase):
         self.assertGreater(hawkes.n_total_jumps,
                            sum(map(len, original_timestamps)))
 
+    def test_hawkes_intensity_contributions(self):
+        """...Test that sum of tracked intensity contributions is identical to tracked_intensity
+        """
+        run_time = 10
+        decay = 0.5
+        baseline = [0.2, 0.4]
+        adjacency = [[0.2, 0.1], [0, 0.3]]
+
+        hawkes = SimuHawkesExpKernels(baseline=baseline, decays=decay,
+                                      adjacency=adjacency, verbose=False,end_time=run_time,
+                                      seed=1393)
+
+        hawkes.track_intensity(run_time)
+        hawkes.simulate()
+
+        for i in range(len(baseline)):
+            np.testing.assert_array_almost_equal(hawkes.tracked_intensity[i],
+                                                 sum(hawkes.tracked_intensity_contributions[i]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Summary of Changes:**

1. New (node,node+1) matrix called intensity_contributions to record intensity per contribution
2. New init_intensity_contributions(intensity_contributions) function to initialise intensity_contributions
3. New update_time_shift_contributions(delay,intensity_contributions) function to update intensity_contributions if intensity is tracked
4. New (node,node+1,timestamp) matrix called itr_contributions to store intensity per contribution during entire simulation if intensity is tracked
5. New tracked_intensity_contributions python property to expose itr_contributions