### PR TITLE
HawkesKernel - swig interface issues

### DIFF
--- a/lib/include/tick/hawkes/simulation/hawkes_kernels/hawkes_kernel.h
+++ b/lib/include/tick/hawkes/simulation/hawkes_kernels/hawkes_kernel.h
@@ -121,6 +121,7 @@ class DLL_PUBLIC HawkesKernel {
    */
   virtual double get_convolution(const double time, const ArrayDouble &timestamps,
                                  double *const bound);
+  // Do we need to include `get_convolution` in the swig interface?
 
   /**
    * Computes the convolution of the process with the primitive of the kernel
@@ -132,6 +133,7 @@ class DLL_PUBLIC HawkesKernel {
    * computed
    */
   virtual double get_primitive_convolution(const double time, const ArrayDouble &timestamps);
+  // Do we need to include `get_primitive_convolution` in the swig interface?
 
   /**
    * Returns the maximum of the kernel after time t

--- a/lib/swig/tick/hawkes/simulation/hawkes_kernels.i
+++ b/lib/swig/tick/hawkes/simulation/hawkes_kernels.i
@@ -14,6 +14,13 @@ class HawkesKernel {
   double get_primitive_value(double t);
   double get_primitive_value(double s, double t);
   virtual double get_norm(int nsteps = 10000);
+  virtual double get_convolution(
+       const double time, 
+       const ArrayDouble &timestamps, 
+       double *const bound);
+  virtual double get_primitive_convolution(
+       const double time, 
+       const ArrayDouble &timestamps);
 };
 
 


### PR DESCRIPTION
Af ew methods of the class `HawkesKernel` give "undefined reference" during the build. How do we fix this?