### PR TITLE
Align PyPI publish workflows with build matrices

### DIFF
--- a/.github/workflows/pythonpublish-linux.yml
+++ b/.github/workflows/pythonpublish-linux.yml
@@ -10,7 +10,11 @@ env:
 
 jobs:
   build:
-    name: build python packages
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -19,7 +23,8 @@ jobs:
 
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
 
     - run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpublish-win.yml
+++ b/.github/workflows/pythonpublish-win.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       max-parallel: 4
       matrix:
@@ -25,6 +25,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: amd64
 
     - run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- `pythonpublish-linux.yml` now builds wheels for Python 3.11/3.12/3.13 (previously only 3.12), matching `build_nix.yml`.
- `pythonpublish-win.yml` pins to `windows-2022` and adds the `ilammy/msvc-dev-cmd@v1` step, matching `build_win.yml` exactly.
- macOS publish left as-is (intentionally ships wheels for all py × runner combinations even where CI excludes some).

## Why
Before #532's build-system migration these gaps didn't matter much, but with scikit-build-core + pybind11 the publish matrix drifted from what CI actually verifies. In particular, 3.11 and 3.13 Linux wheels would not have been produced by the publish pipeline on release.

## Test plan
- [ ] Confirm a release tag triggers all three publish workflows (linux × 3, osx × 4, win × 3).
- [ ] Inspect uploaded artefacts on PyPI for the expected platform/python tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)