### PR TITLE
Fix broken gallery thumbnails in the published docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install docs dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[docs,plot]
+        python -m pip install .[docs]
 
     - name: Build HTML docs
       run: |

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,7 @@ This contains the full documentation of tick, as displayed on the
 [https://x-datainitiative.github.io/tick](https://x-datainitiative.github.io/tick).
 To reproduce the published documentation locally, use Python 3.11+ and run
 
-    python -m pip install .[docs,plot]
+    python -m pip install .[docs]
     make SPHINXBUILD="python -m sphinx" html
 
 This build executes the example gallery and the inline module plots, so if your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ docs = [
   "numpydoc>=1.8",
   "sphinx>=8.0",
   "sphinx-bootstrap-theme>=0.8",
+  "statsmodels>=0.14",
 ]
 dev = [
   "pytest>=8.3",


### PR DESCRIPTION
## Summary
After #535 rebuilt the docs with `make html`, several examples on https://x-datainitiative.github.io/tick/auto_examples/ rendered as black placeholder squares. Two causes in the build log:

* `tick.plot.qq_plots` imports `statsmodels` lazily, so every example that uses it (`plot_hawkes_finance_data`, `plot_hawkes_em`, the `qq_plot_*` group) crashed with `ModuleNotFoundError` during the gallery run, and the extension fell back to the broken-image thumbnail. Fixed by adding `statsmodels` to the `docs` extra.
* `pip install .[docs,plot]` printed `WARNING: tick 0.8.0.1 does not provide the extra 'plot'` — the `plot` extra doesn't exist in `pyproject.toml`; `matplotlib` is already a core dependency. Dropped the phantom `,plot` from the workflow and `doc/README.md`.

## Not in scope
`plot_asynchronous_stochastic_solver.py` still fails with `ASAGA 2 has no history for time`. That's a real bug in the example code (or in solver history tracking for ASAGA) and needs its own fix.

## Test plan
- [ ] Confirm the `Build Docs` workflow no longer prints the `extra 'plot'` warning during install.
- [ ] After merge, verify the gallery pages for `plot_hawkes_em`, `plot_hawkes_finance_data`, and `qq_plot_hawkes_*` show real figures instead of black squares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)