### PR TITLE
Add Python 3.14 support for wheel builds

### DIFF
--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -20,12 +20,14 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         runner: ['macos-15', 'macos-15-intel']
         exclude:
           - python-version: '3.12'
             runner: 'macos-15-intel'
           - python-version: '3.13'
+            runner: 'macos-15-intel'
+          - python-version: '3.14'
             runner: 'macos-15-intel'
 
     steps:

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           arch: amd64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v3.2
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: POSIX",
   "Operating System :: MacOS",
   "Operating System :: Microsoft :: Windows",
@@ -65,7 +66,7 @@ dev = [
 ]
 
 [tool.cibuildwheel]
-build = "cp311-* cp312-* cp313-*"
+build = "cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_* *-win32 *-manylinux_i686"
 build-verbosity = 1
 test-command = "python -c \"import tick; print(tick.__version__)\""


### PR DESCRIPTION
## Summary
- Add `cp314-*` to the cibuildwheel build matrix and `Python :: 3.14` classifier in `pyproject.toml`.
- Add `'3.14'` to the per-OS CI matrices (`build_nix.yml`, `build_osx.yml`, `build_win.yml`), keeping the existing `macos-15-intel` exclusion (no upstream Intel-mac CPython builds for 3.12/3.13/3.14).
- Bump `pypa/cibuildwheel` in `publish.yml` from `v2.21` to `v3.2` — the first release with stable CPython 3.14 support.

## Test plan
- [ ] `Build Tick on Ubuntu` runs green for 3.11–3.14
- [ ] `Build Tick on macOS` runs green for 3.11–3.14 on `macos-15`
- [ ] `Build Tick on Windows` runs green for 3.11–3.14
- [ ] Manually dispatch `Build and publish wheels` and confirm `cp314` wheels appear for linux/macos/windows

Generated with [Claude Code](https://claude.com/claude-code)