### PR TITLE
Bump version to 0.8.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "tick"
-version = "0.8.0.1"
+version = "0.8.0.2"
 description = "Module for statistical learning, with a particular emphasis on time-dependent modelling"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version from `0.8.0.1` → `0.8.0.2` so a release/tag can be cut.

This is the version bump for the first release that ships `cp314` wheels (PR #537).

## Test plan
- [ ] After merge, create GitHub release `v0.8.0.2` to fire `publish.yml` and upload wheels (incl. cp314) to PyPI.

Generated with [Claude Code](https://claude.com/claude-code)